### PR TITLE
Remove arcane syntax from combinators arguments

### DIFF
--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -1,6 +1,5 @@
 import type {
   AllArguments,
-  CollectArguments,
   Composable,
   MergeObjs,
   PipeArguments,
@@ -66,7 +65,7 @@ function pipe<Fns extends [Composable, ...Composable[]]>(
  * const cf = C.all(a, b, c)
 //       ^? Composable<(id: number) => [string, number, boolean]>
  */
-function all<Fns extends Composable[]>(...fns: Fns & AllArguments<Fns>) {
+function all<Fns extends Composable[]>(...fns: Fns) {
   return (async (...args) => {
     const results = await Promise.all(fns.map((fn) => fn(...args)))
 
@@ -92,9 +91,7 @@ function all<Fns extends Composable[]>(...fns: Fns & AllArguments<Fns>) {
  * const df = collect({ a, b })
 //       ^? Composable<() => { a: string, b: number }>
  */
-function collect<Fns extends Record<string, Composable>>(
-  fns: Fns & CollectArguments<Fns>,
-) {
+function collect<Fns extends Record<string, Composable>>(fns: Fns) {
   const fnsWithKey = Object.entries(fns).map(([key, cf]) =>
     map(cf, (result) => ({ [key]: result })),
   )
@@ -119,9 +116,7 @@ function collect<Fns extends Record<string, Composable>>(
  * const cf = C.sequence(a, b)
  * //    ^? Composable<(aNumber: number) => [string, boolean]>
  */
-function sequence<Fns extends [Composable, ...Composable[]]>(
-  ...fns: Fns & PipeArguments<Fns>
-) {
+function sequence<Fns extends [Composable, ...Composable[]]>(...fns: Fns) {
   return (async (...args) => {
     const [head, ...tail] = fns
 
@@ -165,7 +160,7 @@ function map<Fn extends Composable, O>(
  * //    ^? DomainFunction<{ a: string, b: number }>
  */
 function merge<Fns extends Composable[]>(
-  ...fns: Fns & AllArguments<Fns>
+  ...fns: Fns
 ): Composable<
   (...args: Parameters<NonNullable<AllArguments<Fns>[0]>>) => MergeObjs<{
     [key in keyof Fns]: UnpackData<Fns[key]>
@@ -184,7 +179,7 @@ const b = mdf(z.object({ n: z.number() }))(({ n }) => String(n))
 const df = first(a, b)
 //    ^? DomainFunction<string | number>
  */
-function first<Fns extends Composable[]>(...fns: Fns & AllArguments<Fns>) {
+function first<Fns extends Composable[]>(...fns: Fns) {
   return ((...args) => {
     return composable(async () => {
       const results = await Promise.all(fns.map((fn) => fn(...args)))

--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -43,15 +43,13 @@ function mergeObjects<T extends unknown[] = unknown[]>(objs: T): MergeObjs<T> {
  * const d = C.pipe(a, b)
  * //    ^? Composable<({ aNumber }: { aNumber: number }) => { aBoolean: boolean }>
  */
-function pipe<Fns extends [Composable, ...Composable[]]>(
-  ...fns: Fns & PipeArguments<Fns>
-) {
+function pipe<Fns extends [Composable, ...Composable[]]>(...fns: Fns) {
   return (async (...args) => {
     const res = await sequence(...(fns as never))(...(args as never))
     return !res.success
       ? failure(res.errors)
       : success(res.data[res.data.length - 1])
-  }) as PipeReturn<Fns>
+  }) as PipeReturn<PipeArguments<Fns>>
 }
 
 /**

--- a/src/tests/collect.test.ts
+++ b/src/tests/collect.test.ts
@@ -105,8 +105,8 @@ describe('collect', () => {
     >
 
     assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'a is 1')
-    assertEquals(res.errors![1].message, 'a is 1')
+    assertEquals(res.errors[0].message, 'a is 1')
+    assertEquals(res.errors[1].message, 'a is 1')
   })
 
   it('should return error when one of the schema functions has input errors', async () => {

--- a/src/tests/collect.test.ts
+++ b/src/tests/collect.test.ts
@@ -10,8 +10,8 @@ import {
 } from '../index.ts'
 
 const voidFn = composable(() => {})
-const append = composable((a: string, b: string) => `${a}${b}`)
 const toString = withSchema(z.unknown(), z.any())((a) => String(a))
+const append = composable((a: string, b: string) => `${a}${b}`)
 const add = composable((a: number, b: number) => a + b)
 const faultyAdd = composable((a: number, b: number) => {
   if (a === 1) throw new Error('a is 1')
@@ -57,7 +57,6 @@ describe('collect', () => {
 
   it('uses the same arguments for every function', async () => {
     // The runtime will work since passing 1, 2 will be coerced to '1', '2'
-    //@ts-expect-error add and append parameters are incompatible
     const fn = collect({
       add: add,
       string: append,

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -71,7 +71,7 @@ describe('composable', () => {
     type _R = Expect<Equal<typeof res, Result<number>>>
 
     assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'a is 1')
+    assertEquals(res.errors[0].message, 'a is 1')
   })
 })
 

--- a/src/tests/map-error.test.ts
+++ b/src/tests/map-error.test.ts
@@ -35,7 +35,7 @@ describe('mapError', () => {
     type _R = Expect<Equal<typeof res, Result<number>>>
 
     assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'a is 1!!!')
+    assertEquals(res.errors[0].message, 'a is 1!!!')
   })
 
   it('accepts an async mapper', async () => {
@@ -50,7 +50,7 @@ describe('mapError', () => {
     type _R = Expect<Equal<typeof res, Result<number>>>
 
     assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'a is 1!!!')
+    assertEquals(res.errors[0].message, 'a is 1!!!')
   })
 
   it('fails when mapper fail', async () => {
@@ -65,6 +65,6 @@ describe('mapError', () => {
     type _R = Expect<Equal<typeof res, Result<number>>>
 
     assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'Mapper also has problems')
+    assertEquals(res.errors[0].message, 'Mapper also has problems')
   })
 })

--- a/src/tests/map.test.ts
+++ b/src/tests/map.test.ts
@@ -56,7 +56,7 @@ describe('map', () => {
     type _R = Expect<Equal<typeof res, Result<boolean>>>
 
     assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'a is 1')
+    assertEquals(res.errors[0].message, 'a is 1')
   })
 
   it('fails when mapper fail', async () => {
@@ -71,6 +71,6 @@ describe('map', () => {
     type _R = Expect<Equal<typeof res, Result<never>>>
 
     assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'Mapper also has problems')
+    assertEquals(res.errors[0].message, 'Mapper also has problems')
   })
 })

--- a/src/tests/pipe.test.ts
+++ b/src/tests/pipe.test.ts
@@ -2,7 +2,7 @@ import { assertEquals, describe, it } from './prelude.ts'
 import type { Result, Composable } from '../index.ts'
 import { composable, pipe, success } from '../index.ts'
 
-const toString = composable(String)
+const toString = composable((a: unknown) => `${a}`)
 const add = composable((a: number, b: number) => a + b)
 const faultyAdd = composable((a: number, b: number) => {
   if (a === 1) throw new Error('a is 1')
@@ -51,7 +51,7 @@ describe('pipe', () => {
     type _R = Expect<Equal<typeof res, Result<string>>>
 
     assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'a is 1')
+    assertEquals(res.errors[0].message, 'a is 1')
   })
 
   it('catches the errors from function B', async () => {
@@ -61,16 +61,12 @@ describe('pipe', () => {
     const res = await fn(1, 2)
 
     type _FN = Expect<
-      Equal<typeof fn, ['Fail to compose, "never" does not fit in', any]>
+      Equal<typeof fn, ['Fail to compose, "never" does not fit in', unknown]>
     >
     type _R = Expect<Equal<typeof res, Result<string>>>
 
     assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'always throw')
-    assertEquals(
-      // deno-lint-ignore no-explicit-any
-      (res.errors[0] as any).cause,
-      'it was made for this',
-    )
+    assertEquals(res.errors[0].message, 'always throw')
+    assertEquals(res.errors[0].cause, 'it was made for this')
   })
 })

--- a/src/tests/pipe.test.ts
+++ b/src/tests/pipe.test.ts
@@ -55,9 +55,8 @@ describe('pipe', () => {
   })
 
   it('catches the errors from function B', async () => {
-    //@ts-expect-error alwaysThrow won't type-check the composition since its return type is never and toString expects an unknown parameter
     const fn = pipe(add, alwaysThrow, toString)
-    //@ts-expect-error alwaysThrow won't type-check the composition since its return type is never and toString expects an unknown parameter
+    // @ts-expect-error alwaysThrow won't type-check the composition since its return type is never and toString expects an unknown parameter
     const res = await fn(1, 2)
 
     type _FN = Expect<

--- a/src/tests/pipe.test.ts
+++ b/src/tests/pipe.test.ts
@@ -61,8 +61,7 @@ describe('pipe', () => {
     const res = await fn(1, 2)
 
     type _FN = Expect<
-      //@ts-expect-error alwaysThrow won't type-check the composition since its return type is never and toString expects an unknown parameter
-      Equal<typeof fn, Composable<(a: number, b: number) => string>>
+      Equal<typeof fn, ['Fail to compose, "never" does not fit in', any]>
     >
     type _R = Expect<Equal<typeof res, Result<string>>>
 

--- a/src/tests/sequence.test.ts
+++ b/src/tests/sequence.test.ts
@@ -4,7 +4,7 @@ import { composable, sequence, success } from '../index.ts'
 import { withSchema } from '../index.ts'
 
 const toString = composable((a: unknown) => `${a}`)
-const add = withSchema(z.number(), z.number())((a, b) => a + b)
+const schemaAdd = withSchema(z.number(), z.number())((a, b) => a + b)
 const faultyAdd = composable((a: number, b: number) => {
   if (a === 1) throw new Error('a is 1')
   return a + b
@@ -12,13 +12,12 @@ const faultyAdd = composable((a: number, b: number) => {
 
 describe('sequence', () => {
   it('sends the results of the first function to the second and saves every step of the result', async () => {
-    const fn = sequence(add, toString)
+    const fn = sequence(schemaAdd, toString)
     const res = await fn(1, 2)
 
     type _FN = Expect<
       Equal<
         typeof fn,
-        // TODO: this is wrong, it should infer the params
         Composable<(a?: unknown, b?: unknown) => [number, string]>
       >
     >

--- a/src/tests/sequence.test.ts
+++ b/src/tests/sequence.test.ts
@@ -71,6 +71,6 @@ describe('sequence', () => {
     type _R = Expect<Equal<typeof res, Result<[number, string]>>>
 
     assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'a is 1')
+    assertEquals(res.errors[0].message, 'a is 1')
   })
 })

--- a/src/tests/types.test.ts
+++ b/src/tests/types.test.ts
@@ -229,57 +229,6 @@ namespace AllArguments {
   >
 }
 
-namespace CollectArguments {
-  type testNoEmptyArgumentList = Expect<
-    Equal<Subject.CollectArguments<{}>, never>
-  >
-  type testOneComposable = Expect<
-    Equal<
-      Subject.CollectArguments<{ a: Subject.Composable }>,
-      { a: Subject.Composable }
-    >
-  >
-  type testSubtypesForTwoComposables = Expect<
-    Equal<
-      Subject.CollectArguments<{
-        a: Subject.Composable<(x: string, y: 1) => void>
-        b: Subject.Composable<(x: 'foo', y: number) => void>
-      }>,
-      {
-        a: Subject.Composable<(x: 'foo', y: 1) => void>
-        b: Subject.Composable<(x: 'foo', y: 1) => void>
-      }
-    >
-  >
-  type testMaxArityForTwoComposables = Expect<
-    Equal<
-      Subject.CollectArguments<{
-        a: Subject.Composable<(x: string, y: number) => void>
-        b: Subject.Composable<(x: 'foo') => void>
-      }>,
-      {
-        a: Subject.Composable<(x: 'foo', y: number) => void>
-        b: Subject.Composable<(x: 'foo', y: number) => void>
-      }
-    >
-  >
-
-  type testCompositionFailure = Expect<
-    Equal<
-      Subject.CollectArguments<{
-        a: Subject.Composable<(x: string, y: string) => void>
-        b: Subject.Composable<(x: 'foo', y: number) => void>
-      }>,
-      [
-        'Fail to compose',
-        [x: string, y: string],
-        'does not fit in',
-        [x: 'foo', y: number],
-      ]
-    >
-  >
-}
-
 namespace UnpackData {
   type testExtractsDataFromPromisedResult = Expect<
     Equal<Subject.UnpackData<() => Promise<Subject.Result<string>>>, string>

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,7 @@ type PipeReturn<Fns extends any[]> = Fns extends [
     : ['Fail to compose', Awaited<OA>, 'does not fit in', PB]
   : Fns extends [Composable<(...args: infer P) => infer O>]
   ? Composable<(...args: P) => O>
-  : never
+  : Fns
 
 type PipeArguments<
   Fns extends any[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,15 +99,6 @@ type ApplyArgumentsToFns<
   ? ApplyArgumentsToFns<restA, Args, [...Output, (...a: Args) => OA]>
   : Output
 
-type CollectArguments<T extends Record<string, Composable>> = AllArguments<
-  Internal.UnionToTuple<T[keyof T]>
-> extends ['Fail to compose', ...any[]]
-  ? AllArguments<Internal.UnionToTuple<T[keyof T]>>
-  : Internal.Zip<
-      Internal.Keys<T>,
-      AllArguments<Internal.UnionToTuple<T[keyof T]>>
-    >
-
 type RecordToTuple<T extends Record<string, Composable>> =
   Internal.RecordValuesFromKeysTuple<T, Internal.Keys<T>>
 
@@ -144,7 +135,6 @@ type Last<T extends readonly unknown[]> = T extends [...infer _I, infer L]
 
 export type {
   AllArguments,
-  CollectArguments,
   Composable,
   Failure,
   Last,


### PR DESCRIPTION
I was testing out the possibility of removing this `...fns: Fns & SomeHelper<Fns>` syntax which seems to be undocumented and hard to grasp.
The results seem pretty satisfactory for parallel combinators IMO and it also seems to solve the problem with the inline composables being declared in combinators such as `collect`.

Let's study this possibility!