### PR TITLE
branch types

### DIFF
--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -1,9 +1,9 @@
 import type {
-  AllArguments,
   BranchReturn,
+  CanComposeInParallel,
+  CanComposeInSequence,
   Composable,
   MergeObjs,
-  PipeArguments,
   PipeReturn,
   RecordToTuple,
   Result,
@@ -50,7 +50,7 @@ function pipe<Fns extends [Composable, ...Composable[]]>(...fns: Fns) {
     return !res.success
       ? failure(res.errors)
       : success(res.data[res.data.length - 1])
-  }) as PipeReturn<PipeArguments<Fns>>
+  }) as PipeReturn<CanComposeInSequence<Fns>>
 }
 
 /**
@@ -74,7 +74,7 @@ function all<Fns extends Composable[]>(...fns: Fns) {
 
     return success((results as Success[]).map(({ data }) => data))
   }) as Composable<
-    (...args: Parameters<NonNullable<AllArguments<Fns>[0]>>) => {
+    (...args: Parameters<NonNullable<CanComposeInParallel<Fns>[0]>>) => {
       [k in keyof Fns]: UnpackData<Fns[k]>
     }
   >
@@ -97,7 +97,7 @@ function collect<Fns extends Record<string, Composable>>(fns: Fns) {
   return map(all(...(fnsWithKey as any)), mergeObjects) as Composable<
     (
       ...args: Parameters<
-        Exclude<AllArguments<RecordToTuple<Fns>>[0], undefined>
+        Exclude<CanComposeInParallel<RecordToTuple<Fns>>[0], undefined>
       >
     ) => {
       [key in keyof Fns]: UnpackData<Fns[key]>
@@ -129,7 +129,7 @@ function sequence<Fns extends [Composable, ...Composable[]]>(...fns: Fns) {
       result.push(res.data)
     }
     return success(result)
-  }) as SequenceReturn<PipeArguments<Fns>>
+  }) as SequenceReturn<CanComposeInSequence<Fns>>
 }
 
 /**
@@ -161,7 +161,9 @@ function map<Fn extends Composable, O>(
 function merge<Fns extends Composable[]>(
   ...fns: Fns
 ): Composable<
-  (...args: Parameters<NonNullable<AllArguments<Fns>[0]>>) => MergeObjs<
+  (
+    ...args: Parameters<NonNullable<CanComposeInParallel<Fns>[0]>>
+  ) => MergeObjs<
     {
       [key in keyof Fns]: UnpackData<Fns[key]>
     }
@@ -194,7 +196,7 @@ function first<Fns extends Composable[]>(...fns: Fns) {
     })()
   }) as Composable<
     (
-      ...args: Parameters<NonNullable<AllArguments<Fns>[0]>>
+      ...args: Parameters<NonNullable<CanComposeInParallel<Fns>[0]>>
     ) => UnpackData<Fns[number]>
   >
 }

--- a/src/environment/combinators.ts
+++ b/src/environment/combinators.ts
@@ -1,11 +1,7 @@
 import type { Composable } from '../types.ts'
 import * as A from '../combinators.ts'
 import { composable, fromSuccess } from '../constructors.ts'
-import {
-  PipeReturnWithEnvironment,
-  SequenceReturnWithEnvironment,
-} from './types.ts'
-import { BranchReturnWithEnvironment } from './types.ts'
+import { BranchReturn, PipeReturn, SequenceReturn } from './types.ts'
 
 function applyEnvironmentToList<
   Fns extends Array<(input: unknown, environment: unknown) => unknown>,
@@ -31,7 +27,7 @@ function pipe<Fns extends Composable[]>(...fns: Fns) {
   return ((input: any, environment: any) =>
     A.pipe(...applyEnvironmentToList(fns, environment))(
       input,
-    )) as PipeReturnWithEnvironment<Fns>
+    )) as PipeReturn<Fns>
 }
 
 /**
@@ -49,7 +45,7 @@ function sequence<Fns extends Composable[]>(...fns: Fns) {
   return ((input: any, environment: any) =>
     A.sequence(...applyEnvironmentToList(fns, environment))(
       input,
-    )) as SequenceReturnWithEnvironment<Fns>
+    )) as SequenceReturn<Fns>
 }
 
 /**
@@ -92,7 +88,7 @@ function branch<
       if (typeof nextDf !== 'function') return result.data
       return fromSuccess(nextDf)(result.data, environment)
     })()
-  }) as BranchReturnWithEnvironment<SourceComposable, Resolver>
+  }) as BranchReturn<SourceComposable, Resolver>
 }
 
 export { branch, pipe, sequence }

--- a/src/environment/tests/types.test.ts
+++ b/src/environment/tests/types.test.ts
@@ -139,17 +139,17 @@ namespace PipeReturn {
   >
 }
 
-namespace BranchReturn {
-  // type test = Expect<
-  //   Equal<
-  //     Subject.BranchReturn<
-  //       Composable<(a: number, e?: unknown) => number>,
-  //       (a: number) => Composable<(a: number, e: number) => string>
-  //     >,
-  //     Composable<(a: number, e?: unknown) => string>
-  //   >
-  // >
-}
+// namespace BranchReturn {
+//   type test = Expect<
+//     Equal<
+//       Subject.BranchReturn<
+//         Composable<(a: number, e?: unknown) => number>,
+//         (a: number) => Composable<(a: number, e: number) => string>
+//       >,
+//       Composable<(a: number, e: number) => string>
+//     >
+//   >
+// }
 
 namespace GetEnv {
   type test1 = Expect<

--- a/src/environment/tests/types.test.ts
+++ b/src/environment/tests/types.test.ts
@@ -139,17 +139,26 @@ namespace PipeReturn {
   >
 }
 
-// namespace BranchReturn {
-//   type test = Expect<
-//     Equal<
-//       Subject.BranchReturn<
-//         Composable<(a: number, e?: unknown) => number>,
-//         (a: number) => Composable<(a: number, e: number) => string>
-//       >,
-//       Composable<(a: number, e: number) => string>
-//     >
-//   >
-// }
+namespace BranchReturn {
+  type testCommonEnv = Expect<
+    Equal<
+      Subject.BranchReturn<
+        Composable<(a: number, e?: unknown) => number>,
+        (a: number) => Composable<(a: number, e: number) => string>
+      >,
+      Composable<(a: number, e: number) => string>
+    >
+  >
+  type test = Expect<
+    Equal<
+      Subject.BranchReturn<
+        Composable<(a?: unknown, e?: unknown) => number>,
+        (a: number) => null | Composable<(a?: unknown, e?: unknown) => string>
+      >,
+      Composable<(a?: unknown, e?: unknown) => string | number>
+    >
+  >
+}
 
 namespace GetEnv {
   type test1 = Expect<

--- a/src/environment/tests/types.test.ts
+++ b/src/environment/tests/types.test.ts
@@ -85,10 +85,10 @@ namespace CommonEnvironment {
   >
 }
 
-namespace SequenceReturnWithEnvironment {
+namespace SequenceReturn {
   type test = Expect<
     Equal<
-      Subject.SequenceReturnWithEnvironment<
+      Subject.SequenceReturn<
         [
           Composable<(a: number, e?: unknown) => number>,
           Composable<(a: number, e: number) => number>,
@@ -101,7 +101,7 @@ namespace SequenceReturnWithEnvironment {
 
   type test2 = Expect<
     Equal<
-      Subject.SequenceReturnWithEnvironment<
+      Subject.SequenceReturn<
         [
           Composable<(a?: unknown, e?: unknown) => { id: number }>,
           Composable<(a?: unknown, e?: unknown) => number>,
@@ -112,10 +112,10 @@ namespace SequenceReturnWithEnvironment {
   >
 }
 
-namespace PipeReturnWithEnvironment {
+namespace PipeReturn {
   type test = Expect<
     Equal<
-      Subject.PipeReturnWithEnvironment<
+      Subject.PipeReturn<
         [
           Composable<(a: number, e?: unknown) => number>,
           Composable<(a: number, e: number) => number>,
@@ -128,7 +128,7 @@ namespace PipeReturnWithEnvironment {
 
   type test2 = Expect<
     Equal<
-      Subject.PipeReturnWithEnvironment<
+      Subject.PipeReturn<
         [
           Composable<(a?: unknown, e?: unknown) => { id: number }>,
           Composable<(a?: unknown, e?: unknown) => number>,
@@ -137,6 +137,18 @@ namespace PipeReturnWithEnvironment {
       Composable<(a?: unknown, b?: unknown) => number>
     >
   >
+}
+
+namespace BranchReturn {
+  // type test = Expect<
+  //   Equal<
+  //     Subject.BranchReturn<
+  //       Composable<(a: number, e?: unknown) => number>,
+  //       (a: number) => Composable<(a: number, e: number) => string>
+  //     >,
+  //     Composable<(a: number, e?: unknown) => string>
+  //   >
+  // >
 }
 
 namespace GetEnv {

--- a/src/environment/types.ts
+++ b/src/environment/types.ts
@@ -1,5 +1,10 @@
 import { Internal } from '../internal/types.ts'
-import { Composable, PipeReturn, SequenceReturn, UnpackData } from '../types.ts'
+import {
+  Composable,
+  PipeReturn as BasePipeReturn,
+  SequenceReturn as BaseSequenceReturn,
+  UnpackData,
+} from '../types.ts'
 
 type CommonEnvironment<
   Fns extends Composable[],
@@ -19,27 +24,27 @@ type CommonEnvironment<
     : never
   : never
 
-type SequenceReturnWithEnvironment<Fns extends Composable[]> = SequenceReturn<
-  PipeArgumentsWithEnvironment<Fns>
+type SequenceReturn<Fns extends Composable[]> = BaseSequenceReturn<
+  CanComposeInSequence<Fns>
 > extends Composable<(...args: any[]) => infer CReturn>
   ? CommonEnvironment<Fns> extends { 'Incompatible arguments ': true }
     ? CommonEnvironment<Fns>
   : Composable<
     (...args: SetEnv<Parameters<Fns[0]>, CommonEnvironment<Fns>>) => CReturn
   >
-  : PipeArgumentsWithEnvironment<Fns>
+  : CanComposeInSequence<Fns>
 
-type PipeReturnWithEnvironment<Fns extends Composable[]> = PipeReturn<
-  PipeArgumentsWithEnvironment<Fns>
+type PipeReturn<Fns extends Composable[]> = BasePipeReturn<
+  CanComposeInSequence<Fns>
 > extends Composable<(...args: any[]) => infer CReturn>
   ? CommonEnvironment<Fns> extends { 'Incompatible arguments ': true }
     ? CommonEnvironment<Fns>
   : Composable<
     (...args: SetEnv<Parameters<Fns[0]>, CommonEnvironment<Fns>>) => CReturn
   >
-  : PipeArgumentsWithEnvironment<Fns>
+  : CanComposeInSequence<Fns>
 
-type PipeArgumentsWithEnvironment<
+type CanComposeInSequence<
   Fns extends any[],
   Arguments extends any[] = [],
 > = Fns extends [Composable<(...a: infer PA) => infer OA>, ...infer restA]
@@ -57,7 +62,7 @@ type PipeArgumentsWithEnvironment<
       ? Internal.FailToCompose<never, FirstBParameter>
     : Awaited<OA> extends FirstBParameter
       ? Internal.EveryElementTakes<PB, undefined> extends true
-        ? PipeArgumentsWithEnvironment<
+        ? CanComposeInSequence<
           restA,
           [...Arguments, Composable<(...a: PA) => OA>]
         >
@@ -83,42 +88,37 @@ type SetEnv<
     ? [firstOptional?, ...Env]
   : never
 
-type BranchReturnWithEnvironment<
+type BranchReturn<
   SourceComposable extends Composable,
   Resolver extends (
     ...args: any[]
   ) => Composable | null | Promise<Composable | null>,
-> = PipeArgumentsWithEnvironment<
+> = CanComposeInSequence<
   [SourceComposable, Composable<Resolver>]
 > extends Composable[]
-  ? Awaited<ReturnType<Resolver>> extends null
-    ? SourceComposable
-    : PipeArgumentsWithEnvironment<
-        [SourceComposable, Awaited<ReturnType<Resolver>>]
-      > extends [Composable, ...any]
-    ? Composable<
-        (
-          ...args: Parameters<
-            PipeArgumentsWithEnvironment<
-              [SourceComposable, Awaited<ReturnType<Resolver>>]
-            >[0]
-          >
-        ) => null extends Awaited<ReturnType<Resolver>>
-          ?
-              | UnpackData<SourceComposable>
-              | UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
-          : UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
-      >
-    : PipeArgumentsWithEnvironment<
-        [SourceComposable, Awaited<ReturnType<Resolver>>]
-      >
-  : PipeArgumentsWithEnvironment<[SourceComposable, Composable<Resolver>]>
+  ? Awaited<ReturnType<Resolver>> extends null ? SourceComposable
+  : CanComposeInSequence<
+    [SourceComposable, Awaited<ReturnType<Resolver>>]
+  > extends [Composable, ...any] ? Composable<
+      (
+        ...args: Parameters<
+          CanComposeInSequence<
+            [SourceComposable, Awaited<ReturnType<Resolver>>]
+          >[0]
+        >
+      ) => null extends Awaited<ReturnType<Resolver>> ?
+          | UnpackData<SourceComposable>
+          | UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
+        : UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
+    >
+  : CanComposeInSequence<[SourceComposable, Awaited<ReturnType<Resolver>>]>
+  : CanComposeInSequence<[SourceComposable, Composable<Resolver>]>
 
 export type {
-  BranchReturnWithEnvironment,
+  BranchReturn,
   CommonEnvironment,
   GetEnv,
-  PipeReturnWithEnvironment,
-  SequenceReturnWithEnvironment,
+  PipeReturn,
+  SequenceReturn,
   SetEnv,
 }

--- a/src/environment/types.ts
+++ b/src/environment/types.ts
@@ -88,6 +88,15 @@ type SetEnv<
     ? [firstOptional?, ...Env]
   : never
 
+type BranchEnvironment<
+  SourceComposable extends Composable,
+  Resolver extends (
+    ...args: any[]
+  ) => Composable | null | Promise<Composable | null>,
+> = Awaited<ReturnType<Resolver>> extends Composable<any>
+  ? CommonEnvironment<[SourceComposable, Awaited<ReturnType<Resolver>>]>
+  : GetEnv<Parameters<SourceComposable>>
+
 type BranchReturn<
   SourceComposable extends Composable,
   Resolver extends (
@@ -101,10 +110,13 @@ type BranchReturn<
     [SourceComposable, Awaited<ReturnType<Resolver>>]
   > extends [Composable, ...any] ? Composable<
       (
-        ...args: Parameters<
-          CanComposeInSequence<
-            [SourceComposable, Awaited<ReturnType<Resolver>>]
-          >[0]
+        ...args: SetEnv<
+          Parameters<
+            CanComposeInSequence<
+              [SourceComposable, Awaited<ReturnType<Resolver>>]
+            >[0]
+          >,
+          BranchEnvironment<SourceComposable, Resolver>
         >
       ) => null extends Awaited<ReturnType<Resolver>> ?
           | UnpackData<SourceComposable>

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -70,10 +70,10 @@ namespace Internal {
         ? restK extends string[]
           ? restV extends unknown[]
             ? Prettify<Zip<restK, restV, O & { [key in HeadK]: HeadV }>>
-          : V // in this case V has the AllArguments failure type
+          : V // in this case V has the CanComposeInParallel failure type
         : never
       : never
-    : O
+    : never
     : O
 
   export type EveryElementTakes<T extends any[], U> = T extends [

--- a/src/tests/branch.test.ts
+++ b/src/tests/branch.test.ts
@@ -10,15 +10,20 @@ import { Composable } from '../types.ts'
 import { branch } from '../combinators.ts'
 
 describe('branch', () => {
-  it('should pipe a composable with arbitrary pipes', async () => {
+  it('should pipe a composable with arbitrary types', async () => {
     const a = composable(({ id }: { id: number }) => ({
       id: id + 2,
     }))
     const b = composable(({ id }: { id: number }) => id - 1)
 
-    const c = branch(a, () => Promise.resolve(b))
+    const c = branch(a, (i: { id: number }) =>
+      i.id % 2 === 0 ? Promise.resolve(b) : Promise.resolve(a),
+    )
     type _R = Expect<
-      Equal<typeof c, Composable<(input: { id: number }) => number>>
+      Equal<
+        typeof c,
+        Composable<(input: { id: number }) => number | { id: number }>
+      >
     >
 
     assertEquals(await c({ id: 1 }), success(2))
@@ -69,7 +74,7 @@ describe('branch', () => {
       id: id + 2,
     }))
     const b = withSchema(z.object({ id: z.number() }))(({ id }) => id - 1)
-    const c = branch(a, () => b)
+    const c = branch(a, (i: { id: number }) => b)
     type _R = Expect<
       Equal<
         typeof c,
@@ -88,7 +93,7 @@ describe('branch', () => {
       id: String(id),
     }))
     const b = withSchema(z.object({ id: z.number() }))(({ id }) => id - 1)
-    const c = branch(a, () => b)
+    const c = branch(a, (i: { id: string }) => b)
     type _R = Expect<
       Equal<
         typeof c,

--- a/src/tests/branch.test.ts
+++ b/src/tests/branch.test.ts
@@ -70,7 +70,7 @@ describe('branch', () => {
       id: id + 2,
     }))
     const b = withSchema(z.object({ id: z.number() }))(({ id }) => id - 1)
-    const c = branch(a, (i: { id: number }) => b)
+    const c = branch(a, () => b)
     type _R = Expect<
       Equal<
         typeof c,
@@ -89,7 +89,7 @@ describe('branch', () => {
       id: String(id),
     }))
     const b = withSchema(z.object({ id: z.number() }))(({ id }) => id - 1)
-    const c = branch(a, (i: { id: string }) => b)
+    const c = branch(a, () => b)
     type _R = Expect<
       Equal<
         typeof c,

--- a/src/tests/branch.test.ts
+++ b/src/tests/branch.test.ts
@@ -16,14 +16,9 @@ describe('branch', () => {
     }))
     const b = composable(({ id }: { id: number }) => id - 1)
 
-    const c = branch(a, (i: { id: number }) =>
-      i.id % 2 === 0 ? Promise.resolve(b) : Promise.resolve(a),
-    )
+    const c = branch(a, () => Promise.resolve(b))
     type _R = Expect<
-      Equal<
-        typeof c,
-        Composable<(input: { id: number }) => number | { id: number }>
-      >
+      Equal<typeof c, Composable<(input: { id: number }) => number>>
     >
 
     assertEquals(await c({ id: 1 }), success(2))
@@ -57,12 +52,13 @@ describe('branch', () => {
     type _R = Expect<
       Equal<
         typeof d,
-        Composable<
-          (
-            input?: unknown,
-            environment?: unknown,
-          ) => string | { id: number; next: string }
-        >
+        | Composable<
+            (
+              input?: unknown,
+              environment?: unknown,
+            ) => { id: number; next: string }
+          >
+        | Composable<(input?: unknown, environment?: unknown) => string>
       >
     >
 

--- a/src/tests/branch.test.ts
+++ b/src/tests/branch.test.ts
@@ -52,13 +52,12 @@ describe('branch', () => {
     type _R = Expect<
       Equal<
         typeof d,
-        | Composable<
-            (
-              input?: unknown,
-              environment?: unknown,
-            ) => { id: number; next: string }
-          >
-        | Composable<(input?: unknown, environment?: unknown) => string>
+        Composable<
+          (
+            input?: unknown,
+            environment?: unknown,
+          ) => string | { id: number; next: string }
+        >
       >
     >
 

--- a/src/tests/types.test.ts
+++ b/src/tests/types.test.ts
@@ -243,6 +243,130 @@ namespace AllArguments {
   >
 }
 
+namespace BranchReturn {
+  type resolverNotReturningComposable = Expect<
+    Equal<
+      Subject.BranchReturn<Subject.Composable<() => number>, () => null>,
+      Subject.Composable<() => number>
+    >
+  >
+  type resolverWithParamsThatDontCompose = Expect<
+    Equal<
+      Subject.BranchReturn<
+        Subject.Composable<() => number>,
+        (i: string) => null
+      >,
+      ['Fail to compose', number, 'does not fit in', string]
+    >
+  >
+  type resolverWithParamsThatCompose = Expect<
+    Equal<
+      Subject.BranchReturn<
+        Subject.Composable<() => number>,
+        (i: number) => null
+      >,
+      Subject.Composable<() => number>
+    >
+  >
+  type resolverWithPromise = Expect<
+    Equal<
+      Subject.BranchReturn<
+        Subject.Composable<() => number>,
+        (i: number) => Promise<null>
+      >,
+      Subject.Composable<() => number>
+    >
+  >
+
+  type returningComposableDoesntMatch = Expect<
+    Equal<
+      Subject.BranchReturn<
+        Subject.Composable<() => number>,
+        (i: number) => Subject.Composable<(i: string) => number>
+      >,
+      ['Fail to compose', number, 'does not fit in', string]
+    >
+  >
+
+  type returningComposableUnionDoesntMatch = Expect<
+    Equal<
+      Subject.BranchReturn<
+        Subject.Composable<() => number>,
+        (
+          i: number,
+        ) =>
+          | Subject.Composable<(i: string) => number>
+          | Subject.Composable<(i: number) => boolean>
+      >,
+      ['Fail to compose', number, 'does not fit in', never]
+    >
+  >
+
+  type resolverUnionMatches = Expect<
+    Equal<
+      Subject.BranchReturn<
+        Subject.Composable<() => { s: string; n: number }>,
+        (i: {
+          n: number
+        }) =>
+          | Subject.Composable<(i: { s: string }) => number>
+          | Subject.Composable<(i: { n: number }) => boolean>
+      >,
+      Subject.Composable<() => number | boolean>
+    >
+  >
+  type resolverMatches = Expect<
+    Equal<
+      Subject.BranchReturn<
+        Subject.Composable<() => number>,
+        (
+          i: number,
+        ) =>
+          | Subject.Composable<(i: number) => number>
+          | Subject.Composable<(i: number) => boolean>
+      >,
+      Subject.Composable<() => number | boolean>
+    >
+  >
+
+  // Resolver is async
+  type asyncResolver = Expect<
+    Equal<
+      Subject.BranchReturn<
+        Subject.Composable<(i: string) => number>,
+        (
+          i: number,
+        ) => Promise<
+          | Subject.Composable<(i: number) => number>
+          | Subject.Composable<(i: number) => boolean>
+        >
+      >,
+      Subject.Composable<(i: string) => number | boolean>
+    >
+  >
+
+  type resolverMayBeNull = Expect<
+    Equal<
+      Subject.BranchReturn<
+        Subject.Composable<() => number>,
+        (i: number) => Subject.Composable<(i: number) => boolean> | null
+      >,
+      Subject.Composable<() => number | boolean>
+    >
+  >
+  type asyncResolverMayBeNull = Expect<
+    Equal<
+      Subject.BranchReturn<
+        Subject.Composable<() => number>,
+        (
+          i: number,
+        ) => Promise<Subject.Composable<(i: number) => boolean> | null>
+      >,
+      Subject.Composable<() => number | boolean>
+    >
+  >
+}
+
 namespace UnpackData {
   type testExtractsDataFromPromisedResult = Expect<
     Equal<Subject.UnpackData<() => Promise<Subject.Result<string>>>, string>

--- a/src/tests/types.test.ts
+++ b/src/tests/types.test.ts
@@ -51,14 +51,19 @@ namespace PipeReturn {
   >
 }
 
-namespace PipeArguments {
-  type testNoEmptyArgumentList = Expect<Equal<Subject.PipeArguments<[]>, never>>
+namespace CanComposeInSequence {
+  type testNoEmptyArgumentList = Expect<
+    Equal<Subject.CanComposeInSequence<[]>, never>
+  >
   type testOneComposable = Expect<
-    Equal<Subject.PipeArguments<[Subject.Composable]>, [Subject.Composable]>
+    Equal<
+      Subject.CanComposeInSequence<[Subject.Composable]>,
+      [Subject.Composable]
+    >
   >
   type testForTwoComposables = Expect<
     Equal<
-      Subject.PipeArguments<
+      Subject.CanComposeInSequence<
         [
           Subject.Composable<(x: string) => number>,
           Subject.Composable<(y: number) => boolean>,
@@ -72,7 +77,7 @@ namespace PipeArguments {
   >
   type testForComponentsWithArityGreaterThan1WithOptionalParameters = Expect<
     Equal<
-      Subject.PipeArguments<
+      Subject.CanComposeInSequence<
         [
           Subject.Composable<(x: string) => number>,
           Subject.Composable<(y: number, optionalArgument?: string) => boolean>,
@@ -86,7 +91,7 @@ namespace PipeArguments {
   >
   type testForComponentsWithArityGreaterThan1 = Expect<
     Equal<
-      Subject.PipeArguments<
+      Subject.CanComposeInSequence<
         [
           Subject.Composable<(x: string) => number>,
           Subject.Composable<(y: number, willBeUndefined: string) => boolean>,
@@ -97,7 +102,7 @@ namespace PipeArguments {
   >
   type testFailureToCompose = Expect<
     Equal<
-      Subject.PipeArguments<
+      Subject.CanComposeInSequence<
         [
           Subject.Composable<(x: string) => void>,
           Subject.Composable<(y: number) => boolean>,
@@ -108,7 +113,7 @@ namespace PipeArguments {
   >
   type testFailureToComposeOnThirdElement = Expect<
     Equal<
-      Subject.PipeArguments<
+      Subject.CanComposeInSequence<
         [
           Subject.Composable<(x: string) => number>,
           Subject.Composable<(y: number) => string>,
@@ -120,14 +125,19 @@ namespace PipeArguments {
   >
 }
 
-namespace AllArguments {
-  type testNoEmptyArgumentList = Expect<Equal<Subject.AllArguments<[]>, never>>
+namespace CanComposeInParallel {
+  type testNoEmptyArgumentList = Expect<
+    Equal<Subject.CanComposeInParallel<[]>, never>
+  >
   type testOneComposable = Expect<
-    Equal<Subject.AllArguments<[Subject.Composable]>, [Subject.Composable]>
+    Equal<
+      Subject.CanComposeInParallel<[Subject.Composable]>,
+      [Subject.Composable]
+    >
   >
   type testSubtypesForTwoComposables = Expect<
     Equal<
-      Subject.AllArguments<
+      Subject.CanComposeInParallel<
         [
           Subject.Composable<(x: string, y: 1) => void>,
           Subject.Composable<(x: 'foo', y: number) => void>,
@@ -141,7 +151,7 @@ namespace AllArguments {
   >
   type testSubtypesForThreeComposables = Expect<
     Equal<
-      Subject.AllArguments<
+      Subject.CanComposeInParallel<
         [
           Subject.Composable<(x: unknown) => void>,
           Subject.Composable<(x: string) => void>,
@@ -157,7 +167,7 @@ namespace AllArguments {
   >
   type testSubtypesForStricterOptional = Expect<
     Equal<
-      Subject.AllArguments<
+      Subject.CanComposeInParallel<
         [
           Subject.Composable<(x: string, y?: 1) => void>,
           Subject.Composable<(x: 'foo', y: number) => void>,
@@ -171,7 +181,7 @@ namespace AllArguments {
   >
   type testSubtypesForOptionalsOnBoth = Expect<
     Equal<
-      Subject.AllArguments<
+      Subject.CanComposeInParallel<
         [
           Subject.Composable<(x: string, y?: number) => void>,
           Subject.Composable<(x: 'foo', y?: number) => void>,
@@ -185,7 +195,7 @@ namespace AllArguments {
   >
   type testSubtypesForConflictingOptionals = Expect<
     Equal<
-      Subject.AllArguments<
+      Subject.CanComposeInParallel<
         [
           Subject.Composable<(x: string, y?: number) => void>,
           Subject.Composable<(x: 'foo', y?: string) => void>,
@@ -199,7 +209,7 @@ namespace AllArguments {
   >
   type testMaxArityForTwoComposables = Expect<
     Equal<
-      Subject.AllArguments<
+      Subject.CanComposeInParallel<
         [
           Subject.Composable<(x: string, y: number) => void>,
           Subject.Composable<(x: 'foo') => void>,
@@ -213,7 +223,7 @@ namespace AllArguments {
   >
   type testMaxArityForTwoComposablesInverse = Expect<
     Equal<
-      Subject.AllArguments<
+      Subject.CanComposeInParallel<
         [
           Subject.Composable<(x: string) => void>,
           Subject.Composable<(x: 'foo', y: number) => void>,
@@ -227,7 +237,7 @@ namespace AllArguments {
   >
   type testCompositionFailure = Expect<
     Equal<
-      Subject.AllArguments<
+      Subject.CanComposeInParallel<
         [
           Subject.Composable<(x: string, y: string) => void>,
           Subject.Composable<(x: 'foo', y: number) => void>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,19 +128,18 @@ type BranchReturn<
 > = PipeArguments<[SourceComposable, Composable<Resolver>]> extends Composable[]
   ? ReturnType<Resolver> extends null | Promise<null>
     ? SourceComposable
-    : ReturnType<Resolver> extends Promise<infer CorNULL>
-    ?
-        | PipeReturn<
-            PipeArguments<[SourceComposable, Extract<CorNULL, Composable>]>
-          >
-        | (null extends CorNULL ? SourceComposable : never)
     :
         | PipeReturn<
             PipeArguments<
-              [SourceComposable, Extract<ReturnType<Resolver>, Composable>]
+              [
+                SourceComposable,
+                Extract<Awaited<ReturnType<Resolver>>, Composable>,
+              ]
             >
           >
-        | (null extends ReturnType<Resolver> ? SourceComposable : never)
+        | (null extends Awaited<ReturnType<Resolver>>
+            ? SourceComposable
+            : never)
   : PipeArguments<[SourceComposable, Composable<Resolver>]>
 
 // Testing resolver compatibility

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,10 @@ type ParserSchema<T extends unknown = unknown> = {
 type Last<T extends readonly unknown[]> = T extends [...infer _I, infer L] ? L
   : never
 
+type PrettifyComposableUnion<C extends Composable> = Composable<
+  (...args: Parameters<C>) => UnpackData<C>
+>
+
 type BranchReturn<
   SourceComposable extends Composable,
   Resolver extends (
@@ -128,7 +132,7 @@ type BranchReturn<
 > = PipeArguments<[SourceComposable, Composable<Resolver>]> extends Composable[]
   ? ReturnType<Resolver> extends null | Promise<null>
     ? SourceComposable
-    :
+    : PrettifyComposableUnion<
         | PipeReturn<
             PipeArguments<
               [
@@ -140,6 +144,7 @@ type BranchReturn<
         | (null extends Awaited<ReturnType<Resolver>>
             ? SourceComposable
             : never)
+      >
   : PipeArguments<[SourceComposable, Composable<Resolver>]>
 
 // Testing resolver compatibility

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,7 @@ type PipeReturn<Fns extends Composable[]> = Fns extends [
 ] ? Composable<(...args: P) => UnpackData<Extract<Last<Fns>, Composable>>>
   : Fns
 
-type PipeArguments<
+type CanComposeInSequence<
   Fns extends any[],
   Arguments extends any[] = [],
 > = Fns extends [Composable<(...a: infer PA) => infer OA>, ...infer restA]
@@ -68,18 +68,22 @@ type PipeArguments<
       ? Internal.FailToCompose<never, FirstBParameter>
     : Awaited<OA> extends FirstBParameter
       ? Internal.EveryElementTakes<PB, undefined> extends true
-        ? PipeArguments<restA, [...Arguments, Composable<(...a: PA) => OA>]>
+        ? CanComposeInSequence<
+          restA,
+          [...Arguments, Composable<(...a: PA) => OA>]
+        >
       : Internal.EveryElementTakes<PB, undefined>
     : Internal.FailToCompose<Awaited<OA>, FirstBParameter>
   : [...Arguments, Composable<(...a: PA) => OA>]
   : never
 
-type AllArguments<
+type CanComposeInParallel<
   Fns extends any[],
   OriginalFns extends any[] = Fns,
 > = Fns extends [Composable<(...a: infer PA) => any>, ...infer restA]
   ? restA extends [Composable<(...b: infer PB) => infer OB>, ...infer restB]
-    ? Internal.SubtypesTuple<PA, PB> extends [...infer MergedP] ? AllArguments<
+    ? Internal.SubtypesTuple<PA, PB> extends [...infer MergedP]
+      ? CanComposeInParallel<
         [Composable<(...args: MergedP) => OB>, ...restB],
         OriginalFns
       >
@@ -125,36 +129,36 @@ type BranchReturn<
   Resolver extends (
     ...args: any[]
   ) => Composable | null | Promise<Composable | null>,
-> = PipeArguments<[SourceComposable, Composable<Resolver>]> extends Composable[]
-  ? Awaited<ReturnType<Resolver>> extends null
-    ? SourceComposable
-    : PipeArguments<[SourceComposable, Awaited<ReturnType<Resolver>>]> extends [
-        Composable,
-        ...any,
-      ]
-    ? Composable<
-        (
-          ...args: Parameters<
-            PipeArguments<[SourceComposable, Awaited<ReturnType<Resolver>>]>[0]
-          >
-        ) => null extends Awaited<ReturnType<Resolver>>
-          ?
-              | UnpackData<SourceComposable>
-              | UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
-          : UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
-      >
-    : PipeArguments<[SourceComposable, Awaited<ReturnType<Resolver>>]>
-  : PipeArguments<[SourceComposable, Composable<Resolver>]>
+> = CanComposeInSequence<
+  [SourceComposable, Composable<Resolver>]
+> extends Composable[]
+  ? Awaited<ReturnType<Resolver>> extends null ? SourceComposable
+  : CanComposeInSequence<
+    [SourceComposable, Awaited<ReturnType<Resolver>>]
+  > extends [Composable, ...any] ? Composable<
+      (
+        ...args: Parameters<
+          CanComposeInSequence<
+            [SourceComposable, Awaited<ReturnType<Resolver>>]
+          >[0]
+        >
+      ) => null extends Awaited<ReturnType<Resolver>> ?
+          | UnpackData<SourceComposable>
+          | UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
+        : UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
+    >
+  : CanComposeInSequence<[SourceComposable, Awaited<ReturnType<Resolver>>]>
+  : CanComposeInSequence<[SourceComposable, Composable<Resolver>]>
 
 export type {
-  AllArguments,
   BranchReturn,
+  CanComposeInParallel,
+  CanComposeInSequence,
   Composable,
   Failure,
   Last,
   MergeObjs,
   ParserSchema,
-  PipeArguments,
   PipeReturn,
   RecordToTuple,
   Result,

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,10 @@ type PrettifyComposableUnion<C extends Composable> = Composable<
   (...args: Parameters<C>) => UnpackData<C>
 >
 
+type G = PrettifyComposableUnion<
+  Composable<() => boolean> | Composable<() => number>
+>
+
 type BranchReturn<
   SourceComposable extends Composable,
   Resolver extends (
@@ -132,7 +136,10 @@ type BranchReturn<
 > = PipeArguments<[SourceComposable, Composable<Resolver>]> extends Composable[]
   ? ReturnType<Resolver> extends null | Promise<null>
     ? SourceComposable
-    : PrettifyComposableUnion<
+    : PipeArguments<
+        [SourceComposable, Extract<Awaited<ReturnType<Resolver>>, Composable>]
+      > extends [Composable<(...args: infer P) => any>, ...any]
+    ? PrettifyComposableUnion<
         | PipeReturn<
             PipeArguments<
               [
@@ -144,6 +151,9 @@ type BranchReturn<
         | (null extends Awaited<ReturnType<Resolver>>
             ? SourceComposable
             : never)
+      >
+    : PipeArguments<
+        [SourceComposable, Extract<Awaited<ReturnType<Resolver>>, Composable>]
       >
   : PipeArguments<[SourceComposable, Composable<Resolver>]>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,30 +129,20 @@ type BranchReturn<
   ? ReturnType<Resolver> extends null | Promise<null>
     ? SourceComposable
     : ReturnType<Resolver> extends Promise<infer CorNULL>
-    ? null extends CorNULL
-      ?
-          | PipeReturn<
-              PipeArguments<[SourceComposable, Extract<CorNULL, Composable>]>
-            >
-          | SourceComposable
-      : PipeReturn<
-          PipeArguments<[SourceComposable, Extract<CorNULL, Composable>]>
-        >
-    : null extends ReturnType<Resolver>
     ?
+        | PipeReturn<
+            PipeArguments<[SourceComposable, Extract<CorNULL, Composable>]>
+          >
+        | (null extends CorNULL ? SourceComposable : never)
+    :
         | PipeReturn<
             PipeArguments<
               [SourceComposable, Extract<ReturnType<Resolver>, Composable>]
             >
           >
-        | SourceComposable
-    : PipeReturn<
-        PipeArguments<
-          [SourceComposable, Extract<ReturnType<Resolver>, Composable>]
-        >
-      >
+        | (null extends ReturnType<Resolver> ? SourceComposable : never)
   : PipeArguments<[SourceComposable, Composable<Resolver>]>
-//
+
 // Testing resolver compatibility
 type X1 = BranchReturn<Composable<() => number>, () => null>
 type X2 = BranchReturn<Composable<() => number>, (i: string) => null>

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,7 +126,7 @@ type BranchReturn<
     ...args: any[]
   ) => Composable | null | Promise<Composable | null>,
 > = UnpackData<SourceComposable> extends Parameters<Resolver>[0]
-  ? ReturnType<Resolver> extends null
+  ? ReturnType<Resolver> extends null | Promise<null>
     ? SourceComposable
     : ReturnType<Resolver> extends Composable<
         (i: infer FirstParameter) => infer COutput
@@ -148,6 +148,24 @@ type BranchReturn<
           sourceOutput: UnpackData<SourceComposable>
           composableFirstParameter: FirstParameter
         }
+    : ReturnType<Resolver> extends Composable<
+        (i: infer FirstParameter) => infer COutput
+      > | null
+    ?
+        | BranchReturn<
+            SourceComposable,
+            (...args: any[]) => Composable<(i: FirstParameter) => COutput>
+          >
+        | BranchReturn<SourceComposable, (...args: any[]) => null>
+    : ReturnType<Resolver> extends Promise<Composable<
+        (i: infer FirstParameter) => infer COutput
+      > | null>
+    ?
+        | BranchReturn<
+            SourceComposable,
+            (...args: any[]) => Composable<(i: FirstParameter) => COutput>
+          >
+        | BranchReturn<SourceComposable, (...args: any[]) => null>
     : never
   : {
       'Incompatible types ': true
@@ -159,6 +177,7 @@ type BranchReturn<
 type X1 = BranchReturn<Composable<() => number>, () => null>
 type X2 = BranchReturn<Composable<() => number>, (i: string) => null>
 type X3 = BranchReturn<Composable<() => number>, (i: number) => null>
+type X31 = BranchReturn<Composable<() => number>, (i: number) => Promise<null>>
 
 // Testing second composable compatibility
 type X4 = BranchReturn<
@@ -196,6 +215,17 @@ type X8 = BranchReturn<
   ) => Promise<
     Composable<(i: number) => number> | Composable<(i: number) => boolean>
   >
+>
+//
+// Resolver might return null
+type X9 = BranchReturn<
+  Composable<() => number>,
+  (i: number) => Composable<(i: number) => boolean> | null
+>
+// Resolver might return null in promise
+type X10 = BranchReturn<
+  Composable<() => number>,
+  (i: number) => Promise<Composable<(i: number) => boolean> | null>
 >
 
 export type {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,13 +42,13 @@ type UnpackAll<List extends Composable[]> = {
   [K in keyof List]: UnpackData<List[K]>
 }
 
-type SequenceReturn<Fns extends Composable[]> = Fns extends [
+type SequenceReturn<Fns extends unknown[]> = Fns extends [
   Composable<(...args: infer P) => any>,
   ...any,
 ] ? Composable<(...args: P) => UnpackAll<Fns>>
   : Fns
 
-type PipeReturn<Fns extends Composable[]> = Fns extends [
+type PipeReturn<Fns extends unknown[]> = Fns extends [
   Composable<(...args: infer P) => any>,
   ...any,
 ] ? Composable<(...args: P) => UnpackData<Extract<Last<Fns>, Composable>>>


### PR DESCRIPTION
- **First draft of BranchReturn type. Still some basic cases failing.**
- **Cover cases where there might be a null or composable in resolver**

## TODO
- [x] Ensure all current cases are green in tests and work as expected.
- [x] Prettify result for union of composables?
- [x] Allow resolver and composable to have zero parameters.
- [x] Ensure that after the first argument resolver and composable can take undefined.
- [x] Convert X types into type tests for `BranchReturn`.
- [x] Investigate additional cases.
- [x] Implement `BranchReturnWithEnvironment`.