### PR TITLE
unify composition type errors

### DIFF
--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -92,7 +92,7 @@ function all<Fns extends Composable[]>(...fns: Fns) {
  */
 function collect<Fns extends Record<string, Composable>>(fns: Fns) {
   const fnsWithKey = Object.entries(fns).map(([key, cf]) =>
-    map(cf, (result) => ({ [key]: result })),
+    map(cf, (result) => ({ [key]: result }))
   )
   return map(all(...(fnsWithKey as any)), mergeObjects) as Composable<
     (
@@ -188,9 +188,11 @@ function merge<Fns extends Composable[]>(
 ): Composable<
   (
     ...args: Parameters<NonNullable<CanComposeInParallel<Fns>[0]>>
-  ) => MergeObjs<{
-    [key in keyof Fns]: UnpackData<Fns[key]>
-  }>
+  ) => MergeObjs<
+    {
+      [key in keyof Fns]: UnpackData<Fns[key]>
+    }
+  >
 > {
   return map(all(...(fns as never)), mergeObjects)
 }
@@ -244,9 +246,8 @@ function catchError<
   (
     ...args: Parameters<Fn>
   ) => Awaited<ReturnType<C>> extends never[]
-    ? UnpackData<Fn> extends any[]
-      ? UnpackData<Fn>
-      : Awaited<ReturnType<C>> | UnpackData<Fn>
+    ? UnpackData<Fn> extends any[] ? UnpackData<Fn>
+    : Awaited<ReturnType<C>> | UnpackData<Fn>
     : Awaited<ReturnType<C>> | UnpackData<Fn>
 > {
   return async (...args: Parameters<Fn>) => {

--- a/src/environment/tests/pipe.test.ts
+++ b/src/environment/tests/pipe.test.ts
@@ -9,6 +9,7 @@ import {
   withSchema,
 } from '../../index.ts'
 import type { Composable } from '../../index.ts'
+import { Internal } from '../../internal/types.ts'
 
 describe('pipe', () => {
   it('should compose functions from left-to-right', async () => {
@@ -158,7 +159,7 @@ describe('pipe', () => {
     type _FN = Expect<
       Equal<
         typeof fn,
-        ['Fail to compose', undefined, 'does not fit in', boolean]
+        Internal.FailToCompose<undefined, boolean>
       >
     >
   })
@@ -174,7 +175,7 @@ describe('pipe', () => {
     const res = await fn(1, 2)
 
     type _FN = Expect<
-      Equal<typeof fn, ['Fail to compose', number, 'does not fit in', string]>
+      Equal<typeof fn, Internal.FailToCompose<number, string>>
     >
   })
 

--- a/src/environment/tests/types.test.ts
+++ b/src/environment/tests/types.test.ts
@@ -1,5 +1,6 @@
 // deno-lint-ignore-file no-namespace
 
+import { Internal } from '../../internal/types.ts'
 import { Composable } from '../../types.ts'
 import * as Subject from '../types.ts'
 
@@ -64,11 +65,7 @@ namespace CommonEnvironment {
           Composable<(y: number, env: string) => boolean>,
         ]
       >,
-      {
-        'Incompatible arguments ': true
-        argument1: [number]
-        argument2: [string]
-      }
+      Internal.FailToCompose<[number], [string]>
     >
   >
 

--- a/src/environment/types.ts
+++ b/src/environment/types.ts
@@ -27,7 +27,7 @@ type CommonEnvironment<
 type SequenceReturn<Fns extends Composable[]> = BaseSequenceReturn<
   CanComposeInSequence<Fns>
 > extends Composable<(...args: any[]) => infer CReturn>
-  ? CommonEnvironment<Fns> extends { 'Incompatible arguments ': true }
+  ? CommonEnvironment<Fns> extends Internal.IncompatibleArguments
     ? CommonEnvironment<Fns>
   : Composable<
     (...args: SetEnv<Parameters<Fns[0]>, CommonEnvironment<Fns>>) => CReturn
@@ -37,7 +37,7 @@ type SequenceReturn<Fns extends Composable[]> = BaseSequenceReturn<
 type PipeReturn<Fns extends Composable[]> = BasePipeReturn<
   CanComposeInSequence<Fns>
 > extends Composable<(...args: any[]) => infer CReturn>
-  ? CommonEnvironment<Fns> extends { 'Incompatible arguments ': true }
+  ? CommonEnvironment<Fns> extends Internal.IncompatibleArguments
     ? CommonEnvironment<Fns>
   : Composable<
     (...args: SetEnv<Parameters<Fns[0]>, CommonEnvironment<Fns>>) => CReturn

--- a/src/environment/types.ts
+++ b/src/environment/types.ts
@@ -16,7 +16,7 @@ type CommonEnvironment<
   ]
     ? GetEnv<CParameters> extends [unknown?]
       ? Internal.IsIncompatible<Env, GetEnv<CParameters>> extends true
-        ? Internal.IncompatibleArguments<Env, GetEnv<CParameters>>
+        ? Internal.FailToCompose<Env, GetEnv<CParameters>>
       : CommonEnvironment<
         Extract<RestFns, Composable[]>,
         Extract<Internal.CommonSubType<Env, GetEnv<CParameters>>, [unknown?]>

--- a/src/internal/types.test.ts
+++ b/src/internal/types.test.ts
@@ -202,7 +202,7 @@ namespace EveryElementTakes {
   type WithSomeDefined = Expect<
     Equal<
       Internal.EveryElementTakes<[undefined, 'foo', undefined], undefined>,
-      ['Fail to compose', undefined, 'does not fit in', 'foo']
+      Internal.FailToCompose<undefined, 'foo'>
     >
   >
 }

--- a/src/internal/types.test.ts
+++ b/src/internal/types.test.ts
@@ -30,7 +30,7 @@ namespace CommonSubType {
   type WithNoCompatibility = Expect<
     Equal<
       Internal.CommonSubType<number, string>,
-      { 'Incompatible arguments ': true; argument1: number; argument2: string }
+      Internal.FailToCompose<number, string>
     >
   >
 
@@ -100,11 +100,7 @@ namespace SubtypesTuple {
         Parameters<(a: number, b: string) => void>,
         []
       >,
-      {
-        'Incompatible arguments ': true
-        argument1: string
-        argument2: number
-      }
+      Internal.FailToCompose<string, number>
     >
   >
 

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -9,8 +9,7 @@ namespace Internal {
     IncompatibleArguments ? true
     : false
 
-  export type FailToCompose<A, B> = {
-    'Incompatible arguments ': true
+  export type FailToCompose<A, B> = IncompatibleArguments & {
     argument1: A
     argument2: B
   }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -12,7 +12,11 @@ namespace Internal {
   } ? true
     : false
 
-  export type FailToCompose<A, B> = ['Fail to compose', A, 'does not fit in', B]
+  export type FailToCompose<A, B> = {
+    'Incompatible arguments ': true
+    argument1: A
+    argument2: B
+  }
 
   export type Prettify<T> =
     & {

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -96,13 +96,13 @@ namespace Internal {
     : TupleA extends [infer headA, ...infer restA]
       ? TupleB extends [infer headB, ...infer restB]
         ? IsIncompatible<headA, headB> extends true
-          ? IncompatibleArguments<headA, headB>
+          ? FailToCompose<headA, headB>
         : SubtypesTuple<restA, restB, [...Output, CommonSubType<headA, headB>]>
         // TupleB is partial
         // We should handle partial case before recursion
       : TupleB extends Partial<[infer headPartial, ...infer restPartial]>
         ? IsIncompatible<headA, headPartial> extends true
-          ? IncompatibleArguments<headA, headPartial>
+          ? FailToCompose<headA, headPartial>
         : SubtypesTuple<
           restA,
           Partial<restPartial>,
@@ -114,7 +114,7 @@ namespace Internal {
     // We should handle partial case before recursion
       ? TupleA extends Partial<[infer headPartial, ...infer restPartial]>
         ? IsIncompatible<headBNoA, headPartial> extends true
-          ? IncompatibleArguments<headBNoA, headPartial>
+          ? FailToCompose<headBNoA, headPartial>
         : SubtypesTuple<
           restB,
           Partial<restPartial>,
@@ -149,8 +149,8 @@ namespace Internal {
     : B extends { 'Incompatible arguments ': true } ? B
     : A extends Record<PropertyKey, unknown>
       ? B extends Record<PropertyKey, unknown> ? Prettify<A & B>
-      : IncompatibleArguments<A, B>
-    : IncompatibleArguments<A, B>
+      : FailToCompose<A, B>
+    : FailToCompose<A, B>
 }
 
 export type { Internal }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,15 +1,12 @@
 // deno-lint-ignore-file no-namespace
 
 namespace Internal {
-  export type IncompatibleArguments<A, B> = {
+  export type IncompatibleArguments = {
     'Incompatible arguments ': true
-    argument1: A
-    argument2: B
   }
 
-  export type IsIncompatible<A, B> = Internal.CommonSubType<A, B> extends {
-    'Incompatible arguments ': true
-  } ? true
+  export type IsIncompatible<A, B> = Internal.CommonSubType<A, B> extends
+    IncompatibleArguments ? true
     : false
 
   export type FailToCompose<A, B> = {

--- a/src/tests/pipe.test.ts
+++ b/src/tests/pipe.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, describe, it } from './prelude.ts'
 import type { Composable, Result } from '../index.ts'
 import { composable, pipe, success } from '../index.ts'
+import { Internal } from '../internal/types.ts'
 
 const toString = composable((a: unknown) => `${a}`)
 const add = composable((a: number, b: number) => a + b)
@@ -62,7 +63,7 @@ describe('pipe', () => {
     type _FN = Expect<
       Equal<
         typeof fn,
-        ['Fail to compose', undefined, 'does not fit in', number]
+        Internal.FailToCompose<undefined, number>
       >
     >
   })
@@ -73,7 +74,7 @@ describe('pipe', () => {
     const res = await fn(1, 2)
 
     type _FN = Expect<
-      Equal<typeof fn, ['Fail to compose', never, 'does not fit in', unknown]>
+      Equal<typeof fn, Internal.FailToCompose<never, unknown>>
     >
     type _R = Expect<Equal<typeof res, Result<string>>>
 

--- a/src/tests/types.test.ts
+++ b/src/tests/types.test.ts
@@ -2,6 +2,7 @@
 import { withSchema } from '../index.ts'
 import { assertEquals, describe, it } from './prelude.ts'
 import * as Subject from '../types.ts'
+import { Internal } from '../internal/types.ts'
 
 namespace MergeObjs {
   const obj1 = { a: 1, b: 2 } as const
@@ -97,7 +98,7 @@ namespace CanComposeInSequence {
           Subject.Composable<(y: number, willBeUndefined: string) => boolean>,
         ]
       >,
-      ['Fail to compose', undefined, 'does not fit in', string]
+      Internal.FailToCompose<undefined, string>
     >
   >
   type testFailureToCompose = Expect<
@@ -108,7 +109,7 @@ namespace CanComposeInSequence {
           Subject.Composable<(y: number) => boolean>,
         ]
       >,
-      ['Fail to compose', void, 'does not fit in', number]
+      Internal.FailToCompose<void, number>
     >
   >
   type testFailureToComposeOnThirdElement = Expect<
@@ -120,7 +121,7 @@ namespace CanComposeInSequence {
           Subject.Composable<(z: boolean) => void>,
         ]
       >,
-      ['Fail to compose', string, 'does not fit in', boolean]
+      Internal.FailToCompose<string, boolean>
     >
   >
 }
@@ -243,12 +244,7 @@ namespace CanComposeInParallel {
           Subject.Composable<(x: 'foo', y: number) => void>,
         ]
       >,
-      [
-        'Fail to compose',
-        [x: string, y: string],
-        'does not fit in',
-        [x: 'foo', y: number],
-      ]
+      Internal.FailToCompose<[x: string, y: string], [x: 'foo', y: number]>
     >
   >
 }
@@ -266,7 +262,7 @@ namespace BranchReturn {
         Subject.Composable<() => number>,
         (i: string) => null
       >,
-      ['Fail to compose', number, 'does not fit in', string]
+      Internal.FailToCompose<number, string>
     >
   >
   type resolverWithParamsThatCompose = Expect<
@@ -294,7 +290,7 @@ namespace BranchReturn {
         Subject.Composable<() => number>,
         (i: number) => Subject.Composable<(i: string) => number>
       >,
-      ['Fail to compose', number, 'does not fit in', string]
+      Internal.FailToCompose<number, string>
     >
   >
 
@@ -308,7 +304,7 @@ namespace BranchReturn {
           | Subject.Composable<(i: string) => number>
           | Subject.Composable<(i: number) => boolean>
       >,
-      ['Fail to compose', number, 'does not fit in', never]
+      Internal.FailToCompose<number, never>
     >
   >
 
@@ -382,7 +378,7 @@ namespace UnpackData {
     Equal<Subject.UnpackData<() => Promise<Subject.Result<string>>>, string>
   >
 
-  const result = withSchema()(() => ({ name: 'foo' } as const))
+  const result = withSchema()(() => ({ name: 'foo' }) as const)
 
   type test = Expect<
     Equal<Subject.UnpackData<typeof result>, { readonly name: 'foo' }>


### PR DESCRIPTION
This should improve readability for complex types that have to validate composition.

It also eliminates the redundancy of two types used to represent composition failure, using only a new version of `FailToCompose`.

Reuse the `IncompatibleArguments` just to test for errors.
