### PR TITLE
Rename `mapError` to `mapErrors`

### DIFF
--- a/API.md
+++ b/API.md
@@ -12,7 +12,7 @@
   - [catchError](#catcherror)
   - [collect](#collect)
   - [map](#map)
-  - [mapError](#maperror)
+  - [mapErrors](#maperrors)
   - [mapParameters](#mapparameters)
   - [pipe](#pipe)
   - [sequence](#sequence)
@@ -365,9 +365,9 @@ For the example above, the result will be something like this:
 }
 ```
 
-## mapError
+## mapErrors
 
-`mapError` creates a single composable that will apply a transformation over the `Failure` of a failed `Composable`.
+`mapErrors` creates a single composable that will apply a transformation over the `Failure` of a failed `Composable`.
 When the given composable succeeds, its result is returned without changes.
 
 This could be useful when adding any layer of error handling.
@@ -383,7 +383,7 @@ const increment = composable((n: number) => {
 const summarizeErrors = (errors: Error[]) =>
   [new Error('Number of errors: ' + errors.length)]
 
-const incrementWithErrorSummary = mapError(increment, summarizeErrors)
+const incrementWithErrorSummary = mapErrors(increment, summarizeErrors)
 
 const result = await incrementWithErrorSummary({ invalidInput: '1' })
 ```

--- a/README.md
+++ b/README.md
@@ -173,14 +173,14 @@ const getOptionalUser = catchError(getUser, (errors, id) => {
 //    ^? Composable<(id: string) => User | null>
 ```
 
-### Mapping the error
-Sometimes we just need to transform one error into something that would make more sense for the caller. Imagine you have our `getUser` defined above, but we want a custom error type for when the ID is invalid. You can map over the failures using `mapError` and a function with the type `(errors: Error[]) => Error[]`.
+### Mapping the errors
+Sometimes we just need to transform the errors into something that would make more sense for the caller. Imagine you have our `getUser` defined above, but we want a custom error type for when the ID is invalid. You can map over the failures using `mapErrors` and a function with the type `(errors: Error[]) => Error[]`.
 
 ```typescript
-import { mapError } from 'composable-functions'
+import { mapErrors } from 'composable-functions'
 
 class InvalidUserId extends Error {}
-const getUserWithCustomError = mapError(getUser, (errors) =>
+const getUserWithCustomError = mapErrors(getUser, (errors) =>
   errors.map((e) => e.message.includes('Invalid ID') ? new InvalidUserId() : e)
 )
 ```

--- a/migrating-df.md
+++ b/migrating-df.md
@@ -92,11 +92,13 @@ const result = environment.pipe(fn1, fn2)(input, env)
 
 ## Modified combinators
 ### mapError
-The `mapError` function now receives and returns an `Array<Error>` instead of an `ErrorData` - which was removed.
+The `mapError` was renamed to `mapErrors` function and it now receives and returns an `Array<Error>` instead of an `ErrorData` - which was removed.
 Since the new `Failure` is much simpler than `ErrorResult` this change will often lead to simpler code:
 
 ```ts
 // Old DF code:
+import { mapError } from 'domain-functions'
+
 const summarizeErrors = (result: ErrorData) =>
   ({
     errors: [{ message: 'Number of errors: ' + result.errors.length }],
@@ -111,6 +113,8 @@ const summarizeErrors = (result: ErrorData) =>
 const incrementWithErrorSummary = mapError(increment, summarizeErrors)
 
 // New Composable code:
+import { mapErrors } from 'composable-functions'
+
 const isInputError = (e: Error): e is InputError => e instanceof InputError
 const isEnvError = (e: Error): e is EnvironmentError => e instanceof EnvironmentError
 const summarizeErrors = (errors: Error[]) =>
@@ -120,7 +124,7 @@ const summarizeErrors = (errors: Error[]) =>
     new EnvironmentError('Number of environment errors: ' + errors.filter(isEnvError).length),
   ]
 
-const incrementWithErrorSummary = mapError(increment, summarizeErrors)
+const incrementWithErrorSummary = mapErrors(increment, summarizeErrors)
 ```
 
 ### trace
@@ -246,7 +250,7 @@ expect(result.errors).containSubset([{ name: 'InputError', path: ['name'] }])
 | `collectSequence({ name: nameDf, age: ageDf })` | `map(environment.sequence(nameDf, ageDf), ([name, age]) => ({ name, age }))` |
 | `first(df1, df2)` | -- * read docs above |
 | `safeResult(() => { throw new Error('oops') })` | `composable(() => { throw new Error('oops') })` |
-| `mapError(df, (result) => ({ inputErrors: [], environmentErrors: [], errors: [{ message: 'Oops' }] }))` | `mapError(fn, errors => [new Error('Oops')])` |
+| `mapError(df, (result) => ({ inputErrors: [], environmentErrors: [], errors: [{ message: 'Oops' }] }))` | `mapErrors(fn, errors => [new Error('Oops')])` |
 | `trace(({ result, input, environment }) => console.log({ result, input, environment }))(df)` | `trace((result, ...args) => console.log(result, ...args))(fn)` |
 
 

--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -261,15 +261,15 @@ function catchError<
  * @example
  *
  * ```ts
- * import { composable, mapError } from 'composable-functions'
+ * import { composable, mapErrors } from 'composable-functions'
  *
  * const increment = composable(({ id }: { id: number }) => id + 1)
- * const incrementWithErrorSummary = mapError(increment, (result) => ({
+ * const incrementWithErrorSummary = mapErrors(increment, (result) => ({
  *   errors: [{ message: 'Errors count: ' + result.errors.length }],
  * }))
  * ```
  */
-function mapError<Fn extends Composable>(
+function mapErrors<Fn extends Composable>(
   fn: Fn,
   mapper: (err: Error[]) => Error[] | Promise<Error[]>,
 ) {
@@ -367,7 +367,7 @@ export {
   catchError,
   collect,
   map,
-  mapError,
+  mapErrors,
   mapParameters,
   mergeObjects,
   pipe,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export {
   catchError,
   collect,
   map,
-  mapError,
+  mapErrors,
   mapParameters,
   mergeObjects,
   pipe,

--- a/src/tests/map-errors.test.ts
+++ b/src/tests/map-errors.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, describe, it } from './prelude.ts'
 import type { Composable, Result } from '../index.ts'
-import { composable, mapError } from '../index.ts'
+import { composable, mapErrors } from '../index.ts'
 import { success } from '../constructors.ts'
 
 const faultyAdd = composable((a: number, b: number) => {
@@ -12,9 +12,9 @@ const cleanError = (err: Error) => ({
   ...err,
   message: err.message + '!!!',
 })
-describe('mapError', () => {
+describe('mapErrors', () => {
   it('maps over the error results of a Composable function', async () => {
-    const fn = mapError(faultyAdd, (errors) => errors.map(cleanError))
+    const fn = mapErrors(faultyAdd, (errors) => errors.map(cleanError))
     const res = await fn(2, 2)
 
     type _FN = Expect<
@@ -26,7 +26,7 @@ describe('mapError', () => {
   })
 
   it('maps over the error results of a Composable function', async () => {
-    const fn = mapError(faultyAdd, (errors) => errors.map(cleanError))
+    const fn = mapErrors(faultyAdd, (errors) => errors.map(cleanError))
     const res = await fn(1, 2)
 
     type _FN = Expect<
@@ -39,9 +39,8 @@ describe('mapError', () => {
   })
 
   it('accepts an async mapper', async () => {
-    const fn = mapError(
-      faultyAdd,
-      (errors) => Promise.resolve(errors.map(cleanError)),
+    const fn = mapErrors(faultyAdd, (errors) =>
+      Promise.resolve(errors.map(cleanError)),
     )
     const res = await fn(1, 2)
 
@@ -55,7 +54,7 @@ describe('mapError', () => {
   })
 
   it('fails when mapper fail', async () => {
-    const fn = mapError(faultyAdd, () => {
+    const fn = mapErrors(faultyAdd, () => {
       throw new Error('Mapper also has problems')
     })
     const res = await fn(1, 2)


### PR DESCRIPTION
To better express its actual behavior