### PR TITLE
Add tests to serializers and Remove the type parameter from SerializableError

### DIFF
--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -2,7 +2,7 @@ import { EnvironmentError } from './errors.ts'
 import { InputError } from './errors.ts'
 import type { Result, SerializableError, SerializedResult } from './types.ts'
 
-function serializeError<T extends Error>(error: T): SerializableError<T> {
+function serializeError(error: Error): SerializableError {
   if (error instanceof InputError || error instanceof EnvironmentError) {
     return {
       exception: error,

--- a/src/tests/serializer.test.ts
+++ b/src/tests/serializer.test.ts
@@ -1,0 +1,113 @@
+import { assertEquals, describe, it } from './prelude.ts'
+import {
+  serializeError,
+  failure,
+  success,
+  InputError,
+  EnvironmentError,
+} from '../index.ts'
+import { SerializableError } from '../types.ts'
+import { serialize } from '../index.ts'
+import { SerializedResult } from '../types.ts'
+
+describe('serializeError', () => {
+  it('serializes an error into a payload friendly format', () => {
+    const result = serializeError(new Error('Oops!'))
+    type _FN = Expect<Equal<typeof result, SerializableError>>
+
+    assertEquals(result, {
+      message: 'Oops!',
+      exception: new Error('Oops!'),
+      name: 'Error',
+      path: [],
+    })
+  })
+
+  it('serializes custom errors', () => {
+    class MyCustomError extends Error {
+      constructor(message: string) {
+        super(message)
+        this.name = 'MyCustomError'
+      }
+    }
+    const result = serializeError(new MyCustomError('Oops!'))
+
+    assertEquals(result, {
+      message: 'Oops!',
+      exception: new MyCustomError('Oops!'),
+      name: 'MyCustomError',
+      path: [],
+    })
+  })
+
+  it('serializes InputError and EnvironmentError properly', () => {
+    const inputError = new InputError('Oops!', ['foo', 'bar'])
+
+    const result = serializeError(inputError)
+
+    assertEquals(result, {
+      message: 'Oops!',
+      exception: inputError,
+      name: 'InputError',
+      path: ['foo', 'bar'],
+    })
+  })
+
+  it('defaults path to empty list', () => {
+    const environmentError = new EnvironmentError('Oops!')
+
+    const result = serializeError(environmentError)
+
+    assertEquals(result, {
+      message: 'Oops!',
+      exception: environmentError,
+      name: 'EnvironmentError',
+      path: [],
+    })
+  })
+})
+
+describe('serialize', () => {
+  it('serializes a successfull result properly', () => {
+    const result = serialize(success('Hello!'))
+    type _FN = Expect<Equal<typeof result, SerializedResult<'Hello!'>>>
+
+    assertEquals(result, { success: true, data: 'Hello!', errors: [] })
+  })
+
+  it('serializes a failed result properly', () => {
+    const result = serialize(
+      failure([
+        new Error('Oops!'),
+        new InputError('Required'),
+        new EnvironmentError('Not found', ['user', 'name']),
+      ]),
+    )
+
+    type _FN = Expect<Equal<typeof result, SerializedResult<unknown>>>
+
+    assertEquals(result, {
+      success: false,
+      errors: [
+        {
+          message: 'Oops!',
+          exception: new Error('Oops!'),
+          name: 'Error',
+          path: [],
+        },
+        {
+          message: 'Required',
+          exception: new InputError('Required'),
+          name: 'InputError',
+          path: [],
+        },
+        {
+          message: 'Not found',
+          exception: new EnvironmentError('Not found', ['user', 'name']),
+          name: 'EnvironmentError',
+          path: ['user', 'name'],
+        },
+      ],
+    })
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,8 +140,8 @@ type RecordToTuple<T extends Record<string, Composable>> =
 /**
  * A serializable error object.
  */
-type SerializableError<T extends Error = Error> = {
-  exception: T
+type SerializableError = {
+  exception: Error
   message: string
   name: string
   path: string[]


### PR DESCRIPTION
The reason why I removed the type parameter is that it would accept any kind of error.
For instance, a `serializeError(new InputError(''))` would accept `type _FN = Expect<Equal<typeof result, SerializableError<EnvironmentError>>>`.

I think we might don't need that information and I'm even thinking if we should keep the exception at all?