### PR TITLE
Input and Environment default to unknown to be aligned with types expectations

### DIFF
--- a/src/constructors.ts
+++ b/src/constructors.ts
@@ -128,10 +128,10 @@ function applySchema<I, E, A extends Composable>(
   environmentSchema?: ParserSchema<E>,
 ): Composable<(input?: unknown, environment?: unknown) => UnpackData<A>> {
   return async function (input, environment = {}) {
-    const envResult = await (environmentSchema ?? objectSchema).safeParseAsync(
-      environment,
-    )
-    const result = await (inputSchema ?? alwaysUndefinedSchema).safeParseAsync(
+    const envResult = await (
+      environmentSchema ?? alwaysUnknownSchema
+    ).safeParseAsync(environment)
+    const result = await (inputSchema ?? alwaysUnknownSchema).safeParseAsync(
       input,
     )
 
@@ -153,23 +153,8 @@ function applySchema<I, E, A extends Composable>(
   }
 }
 
-const objectSchema: ParserSchema<Record<PropertyKey, unknown>> = {
-  safeParseAsync: (data: unknown) => {
-    if (Object.prototype.toString.call(data) !== '[object Object]') {
-      return Promise.resolve({
-        success: false,
-        error: { issues: [{ path: [], message: 'Expected an object' }] },
-      })
-    }
-    const someRecord = data as Record<PropertyKey, unknown>
-    return Promise.resolve({ success: true, data: someRecord })
-  },
-}
-
-const alwaysUndefinedSchema: ParserSchema<undefined> = {
-  safeParseAsync: (_data: unknown) => {
-    return Promise.resolve({ success: true, data: undefined })
-  },
+const alwaysUnknownSchema: ParserSchema<unknown> = {
+  safeParseAsync: (data: unknown) => Promise.resolve({ success: true, data }),
 }
 
 export { applySchema, composable, failure, fromSuccess, success, withSchema }

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -156,7 +156,7 @@ describe('withSchema', () => {
 
       assertEquals(await handler('some input'), {
         success: true,
-        data: undefined,
+        data: 'some input',
         errors: [],
       })
     })
@@ -186,10 +186,7 @@ describe('withSchema', () => {
         >
       >
 
-      assertEquals(
-        await handler(undefined, ''),
-        failure([new EnvironmentError('Expected an object')]),
-      )
+      assertEquals(await handler(undefined, ''), success('no input!'))
     })
 
     it('returns error when parsing fails', async () => {


### PR DESCRIPTION
I mean, what is the point of defaulting input to `undefined` and environment to `object`?

If we are going to work with the input or environment in the handler and we didn't pass a schema, shouldn't it be unknown anyway and you'll need to check something?

This also aligns with the resulting type: `Composable<(i?: unknown, e?: unknown) => T>`.

I also changed the test that would required the environment to be an object... it doesn't make sense IMO.