### PR TITLE
Offer a `deserialize` and `deserializeError` counterparts to the serializers

### DIFF
--- a/API.md
+++ b/API.md
@@ -26,7 +26,6 @@
   - [ErrorList](#errorlist)
   - [EnvironmentError](#environmenterror)
   - [InputError](#inputerror)
-  - [isGeneralError](#isgeneralerror)
   - [isEnvironmentError](#isenvironmenterror)
   - [isInputError](#isinputerror)
 - [Type-safe runtime utilities](#type-safe-runtime-utilities)
@@ -43,9 +42,7 @@
   - [environment.sequence](#environmentsequence)
 - [Serialization](#serialization)
   - [serialize](#serialize)
-  - [deserialize](#deserialize)
   - [serializeError](#serializeerror)
-  - [deserializeError](#deserializeerror)
 
 
 # Constructors
@@ -678,15 +675,6 @@ const fn = composable(() => {
 ## InputError
 Similar to `EnvironmentError`, an `InputError` is a special kind of error that represents an error in the input schema.
 
-## isGeneralError
-`isGeneralError` is a helper function that will check if an error is not an instance of `InputError` nor `EnvironmentError`.
-
-```ts
-isGeneralError(new Error('yes')) // true
-isGeneralError(new InputError('nope')) // false
-isGeneralError(new EnvironmentError('nope')) // false
-```
-
 ## isEnvironmentError
 `isEnvironmentError` is a helper function that will check if an error is an instance of `EnvironmentError`.
 
@@ -847,7 +835,7 @@ const result = await d(1, { user: { admin: true } })
 ```
 
 # Serialization
-In distributed systems where errors might be serialized across network boundaries, it is important to have a way to serialize errors in a way that they won't lose data and can then be deserialized and understood by the receiving end.
+In distributed systems where errors might be serialized across network boundaries, it is important to preserve information relevant to error handling.
 
 ## serialize
 When serializing a `Result` to send over the wire, some of the `Error[]` information is lost.
@@ -868,20 +856,6 @@ The resulting type is `SerializedResult` which means `Success<T> | { success: fa
 
 Therefore, you can differentiate use the error names and paths.
 
-## deserialize
-
-When deserializing a `SerializedResult` you can use the `deserialize` helper to turn it back into a `Result`:
-
-```ts
-const deserializedResult = deserialize(JSON.parse(serializedResult))
-
-// deserializedResult is:
-{
-  success: false,
-  errors: [new InputError('Oops', ['name'])],
-}
-```
-
 ## serializeError
 `serializeError` is a helper function that will convert a single `Error` into a `SerializableError` object. It is used internally by `serialize`:
 
@@ -892,14 +866,4 @@ const serialized = JSON.stringify(
 
 // serialized is:
 `"{ message: 'Oops', name: 'InputError', path: ['name'] }"`
-```
-
-## deserializeError
-`deserializeError` is a helper function that will convert a `SerializableError` object back into an `Error`. It is used internally by `deserialize`:
-
-```ts
-const deserialized = deserializeError(JSON.parse(serialized))
-
-// deserialized is:
-new InputError('Oops', ['name'])
 ```

--- a/API.md
+++ b/API.md
@@ -852,9 +852,9 @@ const serializedResult = JSON.stringify(serialize({
 `"{ success: false, errors: [{ message: 'Oops', name: 'InputError', path: ['name'] }] }"`
 ```
 
-The resulting type is `SerializedResult` which means `Success<T> | { success: false, errors: SerializableError[] }`.
+The resulting type is `SerializableResult` which means `Success<T> | { success: false, errors: SerializableError[] }`.
 
-Therefore, you can differentiate use the error names and paths.
+Therefore, you can differentiate the error using names and paths.
 
 ## serializeError
 `serializeError` is a helper function that will convert a single `Error` into a `SerializableError` object. It is used internally by `serialize`:

--- a/examples/remix/app/lib/index.ts
+++ b/examples/remix/app/lib/index.ts
@@ -3,7 +3,7 @@ import { json } from '@remix-run/node'
 import {
   catchFailure,
   Result,
-  SerializedResult,
+  SerializableResult,
   composable,
   serialize,
   fromSuccess,
@@ -31,7 +31,7 @@ const envFromCookie = fromSuccess(safeReadCookie)
 const actionResponse = <X>(
   result: Result<X>,
   opts?: RequestInit,
-): TypedResponse<SerializedResult<X>> =>
+): TypedResponse<SerializableResult<X>> =>
   json(serialize(result), { status: result.success ? 200 : 422, ...opts })
 
 const loaderResponseOrThrow = <T extends Result<unknown>>(

--- a/migrating-df.md
+++ b/migrating-df.md
@@ -71,6 +71,18 @@ const serializedResult = JSON.stringify(serialize({
 `"{ success: false, errors: [{ message: 'Oops', name: 'InputError', path: ['name'] }] }"`
 ```
 
+After serialization, you can use the `deserialize` function to get the original `Result` back:
+
+```ts
+const deserializedResult = deserialize(JSON.parse(serializedResult))
+
+// deserializedResult is:
+{
+  success: false,
+  errors: [new InputError('Oops', ['name'])],
+}
+```
+
 ## Combinators which shouldn't be affected
 The parallel combinators like `all` and `collect`, along with `map` and `fromSuccess` should work the same way.
 
@@ -113,15 +125,13 @@ const summarizeErrors = (result: ErrorData) =>
 const incrementWithErrorSummary = mapError(increment, summarizeErrors)
 
 // New Composable code:
-import { mapErrors } from 'composable-functions'
+import { mapErrors, isInputError, isEnvironmentError, isGeneralError } from 'composable-functions'
 
-const isInputError = (e: Error): e is InputError => e instanceof InputError
-const isEnvError = (e: Error): e is EnvironmentError => e instanceof EnvironmentError
 const summarizeErrors = (errors: Error[]) =>
   [
-    new Error('Number of errors: ' + errors.filter(e => !isInputError(e) && !isEnvError(e)).length),
+    new Error('Number of errors: ' + errors.filter(isGeneralError).length,
     new InputError('Number of input errors: ' + errors.filter(isInputError).length),
-    new EnvironmentError('Number of environment errors: ' + errors.filter(isEnvError).length),
+    new EnvironmentError('Number of environment errors: ' + errors.filter(isEnvironmentError).length),
   ]
 
 const incrementWithErrorSummary = mapErrors(increment, summarizeErrors)

--- a/migrating-df.md
+++ b/migrating-df.md
@@ -71,18 +71,6 @@ const serializedResult = JSON.stringify(serialize({
 `"{ success: false, errors: [{ message: 'Oops', name: 'InputError', path: ['name'] }] }"`
 ```
 
-After serialization, you can use the `deserialize` function to get the original `Result` back:
-
-```ts
-const deserializedResult = deserialize(JSON.parse(serializedResult))
-
-// deserializedResult is:
-{
-  success: false,
-  errors: [new InputError('Oops', ['name'])],
-}
-```
-
 ## Combinators which shouldn't be affected
 The parallel combinators like `all` and `collect`, along with `map` and `fromSuccess` should work the same way.
 
@@ -125,11 +113,11 @@ const summarizeErrors = (result: ErrorData) =>
 const incrementWithErrorSummary = mapError(increment, summarizeErrors)
 
 // New Composable code:
-import { mapErrors, isInputError, isEnvironmentError, isGeneralError } from 'composable-functions'
+import { mapErrors, isInputError, isEnvironmentError } from 'composable-functions'
 
 const summarizeErrors = (errors: Error[]) =>
   [
-    new Error('Number of errors: ' + errors.filter(isGeneralError).length,
+    new Error('Number of errors: ' + errors.filter((e) => !isInputError(e) && !isEnvironmentError(e)).length,
     new InputError('Number of input errors: ' + errors.filter(isInputError).length),
     new EnvironmentError('Number of environment errors: ' + errors.filter(isEnvironmentError).length),
   ]

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -58,4 +58,16 @@ class ErrorList extends Error {
   }
 }
 
-export { EnvironmentError, ErrorList, InputError }
+const isInputError = (e: Error): e is InputError => e instanceof InputError
+const isEnvironmentError = (e: Error): e is EnvironmentError =>
+  e instanceof EnvironmentError
+const isError = (e: Error) => !isInputError(e) && !isEnvironmentError(e)
+
+export {
+  EnvironmentError,
+  ErrorList,
+  InputError,
+  isError,
+  isInputError,
+  isEnvironmentError,
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -58,16 +58,21 @@ class ErrorList extends Error {
   }
 }
 
-const isInputError = (e: Error): e is InputError => e instanceof InputError
-const isEnvironmentError = (e: Error): e is EnvironmentError =>
-  e instanceof EnvironmentError
-const isGeneralError = (e: Error) => !isInputError(e) && !isEnvironmentError(e)
+function isInputError(e: { name: string; message: string }): boolean {
+  return e.name === 'InputError'
+}
+
+function isEnvironmentError(e: {
+  name: string
+  message: string
+}): boolean {
+  return e.name === 'EnvironmentError'
+}
 
 export {
   EnvironmentError,
   ErrorList,
   InputError,
-  isGeneralError,
-  isInputError,
   isEnvironmentError,
+  isInputError,
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -61,13 +61,13 @@ class ErrorList extends Error {
 const isInputError = (e: Error): e is InputError => e instanceof InputError
 const isEnvironmentError = (e: Error): e is EnvironmentError =>
   e instanceof EnvironmentError
-const isError = (e: Error) => !isInputError(e) && !isEnvironmentError(e)
+const isGeneralError = (e: Error) => !isInputError(e) && !isEnvironmentError(e)
 
 export {
   EnvironmentError,
   ErrorList,
   InputError,
-  isError,
+  isGeneralError,
   isInputError,
   isEnvironmentError,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,20 @@ export {
   inputFromSearch,
   inputFromUrl,
 } from './input-resolvers.ts'
-export { serialize, serializeError } from './serializer.ts'
-export { EnvironmentError, ErrorList, InputError } from './errors.ts'
+export {
+  deserialize,
+  deserializeError,
+  serialize,
+  serializeError,
+} from './serializer.ts'
+export {
+  EnvironmentError,
+  ErrorList,
+  InputError,
+  isEnvironmentError,
+  isGeneralError,
+  isInputError,
+} from './errors.ts'
 export type {
   Composable,
   Failure,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,18 +25,12 @@ export {
   inputFromSearch,
   inputFromUrl,
 } from './input-resolvers.ts'
-export {
-  deserialize,
-  deserializeError,
-  serialize,
-  serializeError,
-} from './serializer.ts'
+export { serialize, serializeError } from './serializer.ts'
 export {
   EnvironmentError,
   ErrorList,
   InputError,
   isEnvironmentError,
-  isGeneralError,
   isInputError,
 } from './errors.ts'
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export type {
   ParserSchema,
   Result,
   SerializableError,
-  SerializedResult,
+  SerializableResult,
   Success,
   UnpackAll,
   UnpackData,

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -2,15 +2,6 @@ import { EnvironmentError } from './errors.ts'
 import { InputError } from './errors.ts'
 import type { Result, SerializableError, SerializedResult } from './types.ts'
 
-function deserializeError(serializedError: SerializableError): Error {
-  if (serializedError.name === 'InputError')
-    return new InputError(serializedError.message, serializedError.path)
-  if (serializedError.name === 'EnvironmentError')
-    return new EnvironmentError(serializedError.message, serializedError.path)
-
-  return new Error(serializedError.message)
-}
-
 function serializeError(error: Error): SerializableError {
   if (error instanceof InputError || error instanceof EnvironmentError) {
     return {
@@ -28,16 +19,10 @@ function serializeError(error: Error): SerializableError {
   }
 }
 
-function deserialize<T>(result: SerializedResult<T>): Result<T> {
-  if (result.success) return result
-
-  return { success: false, errors: result.errors.map(deserializeError) }
-}
-
 function serialize<T>(result: Result<T>): SerializedResult<T> {
   if (result.success) return result
 
   return { success: false, errors: result.errors.map(serializeError) }
 }
 
-export { deserialize, deserializeError, serialize, serializeError }
+export { serialize, serializeError }

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -1,6 +1,6 @@
 import { EnvironmentError } from './errors.ts'
 import { InputError } from './errors.ts'
-import type { Result, SerializableError, SerializedResult } from './types.ts'
+import type { Result, SerializableError, SerializableResult } from './types.ts'
 
 function serializeError(error: Error): SerializableError {
   if (error instanceof InputError || error instanceof EnvironmentError) {
@@ -19,7 +19,7 @@ function serializeError(error: Error): SerializableError {
   }
 }
 
-function serialize<T>(result: Result<T>): SerializedResult<T> {
+function serialize<T>(result: Result<T>): SerializableResult<T> {
   if (result.success) return result
 
   return { success: false, errors: result.errors.map(serializeError) }

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -2,6 +2,15 @@ import { EnvironmentError } from './errors.ts'
 import { InputError } from './errors.ts'
 import type { Result, SerializableError, SerializedResult } from './types.ts'
 
+function deserializeError(serializedError: SerializableError): Error {
+  if (serializedError.name === 'InputError')
+    return new InputError(serializedError.message, serializedError.path)
+  if (serializedError.name === 'EnvironmentError')
+    return new EnvironmentError(serializedError.message, serializedError.path)
+
+  return new Error(serializedError.message)
+}
+
 function serializeError(error: Error): SerializableError {
   if (error instanceof InputError || error instanceof EnvironmentError) {
     return {
@@ -19,10 +28,16 @@ function serializeError(error: Error): SerializableError {
   }
 }
 
+function deserialize<T>(result: SerializedResult<T>): Result<T> {
+  if (result.success) return result
+
+  return { success: false, errors: result.errors.map(deserializeError) }
+}
+
 function serialize<T>(result: Result<T>): SerializedResult<T> {
   if (result.success) return result
 
   return { success: false, errors: result.errors.map(serializeError) }
 }
 
-export { serialize, serializeError }
+export { deserialize, deserializeError, serialize, serializeError }

--- a/src/tests/errors.test.ts
+++ b/src/tests/errors.test.ts
@@ -1,0 +1,35 @@
+import { assertEquals, describe, it } from './prelude.ts'
+import {
+  isInputError,
+  isEnvironmentError,
+  isGeneralError,
+  InputError,
+  EnvironmentError,
+} from '../index.ts'
+
+describe('isInputError', () => {
+  it('checks if an error is instance of InputError', () => {
+    assertEquals(isInputError(new Error('No')), false)
+    assertEquals(isInputError(new InputError('Yes')), true)
+    assertEquals(isInputError(new EnvironmentError('No')), false)
+  })
+})
+
+describe('isEnvironmentError', () => {
+  it('checks if an error is instance of EnvironmentError', () => {
+    assertEquals(isEnvironmentError(new Error('No')), false)
+    assertEquals(isEnvironmentError(new InputError('No')), false)
+    assertEquals(isEnvironmentError(new EnvironmentError('Yes')), true)
+  })
+})
+
+describe('isGeneralError', () => {
+  it('checks if an error is a general error', () => {
+    class CustomError extends Error {}
+
+    assertEquals(isGeneralError(new Error('Yes')), true)
+    assertEquals(isGeneralError(new InputError('No')), false)
+    assertEquals(isGeneralError(new EnvironmentError('No')), false)
+    assertEquals(isGeneralError(new CustomError('Yes')), true)
+  })
+})

--- a/src/tests/errors.test.ts
+++ b/src/tests/errors.test.ts
@@ -2,7 +2,6 @@ import { assertEquals, describe, it } from './prelude.ts'
 import {
   isInputError,
   isEnvironmentError,
-  isGeneralError,
   InputError,
   EnvironmentError,
 } from '../index.ts'
@@ -20,16 +19,5 @@ describe('isEnvironmentError', () => {
     assertEquals(isEnvironmentError(new Error('No')), false)
     assertEquals(isEnvironmentError(new InputError('No')), false)
     assertEquals(isEnvironmentError(new EnvironmentError('Yes')), true)
-  })
-})
-
-describe('isGeneralError', () => {
-  it('checks if an error is a general error', () => {
-    class CustomError extends Error {}
-
-    assertEquals(isGeneralError(new Error('Yes')), true)
-    assertEquals(isGeneralError(new InputError('No')), false)
-    assertEquals(isGeneralError(new EnvironmentError('No')), false)
-    assertEquals(isGeneralError(new CustomError('Yes')), true)
   })
 })

--- a/src/tests/serializer.test.ts
+++ b/src/tests/serializer.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../index.ts'
 import { SerializableError } from '../types.ts'
 import { serialize } from '../index.ts'
-import { SerializedResult } from '../types.ts'
+import { SerializableResult } from '../types.ts'
 
 describe('serializeError', () => {
   it('serializes an error into a payload friendly format', () => {
@@ -70,7 +70,7 @@ describe('serializeError', () => {
 describe('serialize', () => {
   it('serializes a successfull result properly', () => {
     const result = serialize(success('Hello!'))
-    type _T = Expect<Equal<typeof result, SerializedResult<'Hello!'>>>
+    type _T = Expect<Equal<typeof result, SerializableResult<'Hello!'>>>
 
     assertEquals(result, { success: true, data: 'Hello!', errors: [] })
   })
@@ -84,7 +84,7 @@ describe('serialize', () => {
       ]),
     )
 
-    type _T = Expect<Equal<typeof result, SerializedResult<unknown>>>
+    type _T = Expect<Equal<typeof result, SerializableResult<unknown>>>
 
     assertEquals(result, {
       success: false,

--- a/src/tests/serializer.test.ts
+++ b/src/tests/serializer.test.ts
@@ -1,14 +1,12 @@
 import { assertEquals, describe, it } from './prelude.ts'
 import {
-  deserializeError,
-  deserialize,
-  serializeError,
-  failure,
-  success,
-  InputError,
   EnvironmentError,
+  failure,
+  InputError,
+  serializeError,
+  success,
 } from '../index.ts'
-import { Result, SerializableError } from '../types.ts'
+import { SerializableError } from '../types.ts'
 import { serialize } from '../index.ts'
 import { SerializedResult } from '../types.ts'
 
@@ -111,89 +109,5 @@ describe('serialize', () => {
         },
       ],
     })
-  })
-})
-
-describe('deserializeError', () => {
-  it('deserializes a SerializableError', () => {
-    const err: Partial<SerializableError> = {
-      message: 'Oops',
-      name: 'Error',
-      path: [],
-    }
-    const result = deserializeError(err as SerializableError)
-    type _T = Expect<Equal<typeof result, Error>>
-
-    assertEquals(result.message, 'Oops')
-    assertEquals('path' in result, false)
-    assertEquals(result instanceof Error, true)
-    assertEquals(result instanceof InputError, false)
-    assertEquals(result instanceof EnvironmentError, false)
-  })
-
-  it('deserializes an InputError', () => {
-    const err = serializeError(new InputError('Required', ['name']))
-    const result = deserializeError(err)
-
-    assertEquals(result.message, 'Required')
-    assertEquals('path' in result && result.path, ['name'])
-    assertEquals(result instanceof Error, true)
-    assertEquals(result instanceof InputError, true)
-    assertEquals(result instanceof EnvironmentError, false)
-  })
-
-  it('deserializes an EnvironmentError', () => {
-    const err = serializeError(
-      new EnvironmentError('Not found', ['user', 'name']),
-    )
-    const result = deserializeError(err)
-
-    assertEquals(result.message, 'Not found')
-    assertEquals('path' in result && result.path, ['user', 'name'])
-    assertEquals(result instanceof Error, true)
-    assertEquals(result instanceof InputError, false)
-    assertEquals(result instanceof EnvironmentError, true)
-  })
-
-  it('deserializes a custom error', () => {
-    class MyCustomError extends Error {
-      constructor(message: string) {
-        super(message)
-        this.name = 'MyCustomError'
-      }
-    }
-
-    const err = serializeError(new MyCustomError('Custom error'))
-    const result = deserializeError(err)
-
-    assertEquals(result.message, 'Custom error')
-    assertEquals(result instanceof Error, true)
-    assertEquals(result instanceof InputError, false)
-    assertEquals(result instanceof EnvironmentError, false)
-  })
-})
-
-describe('deserialize', () => {
-  it('deserializes a successfull SerializedResult properly', () => {
-    const result = success('Hello!')
-    const serialized = serialize(result)
-    const deserialized = deserialize(serialized)
-    type _T = Expect<Equal<typeof deserialized, Result<'Hello!'>>>
-
-    assertEquals(deserialized, result)
-  })
-
-  it('deserializes a failed SerializedResult properly', () => {
-    const result = failure([
-      new Error('Oops!'),
-      new InputError('Required'),
-      new EnvironmentError('Not found', ['user', 'name']),
-    ])
-    const serialized = serialize(result)
-    const deserialized = deserialize(serialized)
-
-    type _T = Expect<Equal<typeof deserialized, Result<unknown>>>
-
-    assertEquals(deserialized, result)
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,8 +38,7 @@ type Result<T = void> = Success<T> | Failure
 type MergeObjects<Objs extends unknown[], output = {}> = Objs extends [
   infer first,
   ...infer rest,
-]
-  ? MergeObjects<rest, Internal.Prettify<Omit<output, keyof first> & first>>
+] ? MergeObjects<rest, Internal.Prettify<Omit<output, keyof first> & first>>
   : output
 
 /**
@@ -72,8 +71,7 @@ type UnpackAll<List extends Composable[]> = {
 type SequenceReturn<Fns extends unknown[]> = Fns extends [
   Composable<(...args: infer P) => any>,
   ...any,
-]
-  ? Composable<(...args: P) => UnpackAll<Fns>>
+] ? Composable<(...args: P) => UnpackAll<Fns>>
   : Fns
 
 /**
@@ -84,8 +82,7 @@ type SequenceReturn<Fns extends unknown[]> = Fns extends [
 type PipeReturn<Fns extends unknown[]> = Fns extends [
   Composable<(...args: infer P) => any>,
   ...any,
-]
-  ? Composable<(...args: P) => UnpackData<Extract<Last<Fns>, Composable>>>
+] ? Composable<(...args: P) => UnpackData<Extract<Last<Fns>, Composable>>>
   : Fns
 
 /**
@@ -96,22 +93,22 @@ type CanComposeInSequence<
   Arguments extends any[] = [],
 > = Fns extends [Composable<(...a: infer PA) => infer OA>, ...infer restA]
   ? restA extends [
-      Composable<
-        (firstParameter: infer FirstBParameter, ...b: infer PB) => any
-      >,
-      ...unknown[],
-    ]
+    Composable<
+      (firstParameter: infer FirstBParameter, ...b: infer PB) => any
+    >,
+    ...unknown[],
+  ]
     ? Internal.IsNever<Awaited<OA>> extends true
       ? Internal.FailToCompose<never, FirstBParameter>
-      : Awaited<OA> extends FirstBParameter
+    : Awaited<OA> extends FirstBParameter
       ? Internal.EveryElementTakes<PB, undefined> extends true
         ? CanComposeInSequence<
-            restA,
-            [...Arguments, Composable<(...a: PA) => OA>]
-          >
-        : Internal.EveryElementTakes<PB, undefined>
-      : Internal.FailToCompose<Awaited<OA>, FirstBParameter>
-    : [...Arguments, Composable<(...a: PA) => OA>]
+          restA,
+          [...Arguments, Composable<(...a: PA) => OA>]
+        >
+      : Internal.EveryElementTakes<PB, undefined>
+    : Internal.FailToCompose<Awaited<OA>, FirstBParameter>
+  : [...Arguments, Composable<(...a: PA) => OA>]
   : never
 
 /**
@@ -124,11 +121,11 @@ type CanComposeInParallel<
   ? restA extends [Composable<(...b: infer PB) => infer OB>, ...infer restB]
     ? Internal.SubtypesTuple<PA, PB> extends [...infer MergedP]
       ? CanComposeInParallel<
-          [Composable<(...args: MergedP) => OB>, ...restB],
-          OriginalFns
-        >
-      : Internal.FailToCompose<PA, PB>
-    : Internal.ApplyArgumentsToFns<OriginalFns, PA>
+        [Composable<(...args: MergedP) => OB>, ...restB],
+        OriginalFns
+      >
+    : Internal.FailToCompose<PA, PB>
+  : Internal.ApplyArgumentsToFns<OriginalFns, PA>
   : never
 
 /**
@@ -150,7 +147,7 @@ type SerializableError = {
 /**
  * The serialized output of a Result.
  */
-type SerializedResult<T> =
+type SerializableResult<T> =
   | Success<T>
   | { success: false; errors: SerializableError[] }
 
@@ -160,20 +157,19 @@ type SerializedResult<T> =
 type ParserSchema<T extends unknown = unknown> = {
   safeParse: (a: unknown) =>
     | {
-        success: true
-        data: T
-      }
+      success: true
+      data: T
+    }
     | {
-        success: false
-        error: { issues: { path: PropertyKey[]; message: string }[] }
-      }
+      success: false
+      error: { issues: { path: PropertyKey[]; message: string }[] }
+    }
 }
 
 /**
  * Returns the last element of a tuple type.
  */
-type Last<T extends readonly unknown[]> = T extends [...infer _I, infer L]
-  ? L
+type Last<T extends readonly unknown[]> = T extends [...infer _I, infer L] ? L
   : never
 
 /**
@@ -187,25 +183,22 @@ type BranchReturn<
 > = CanComposeInSequence<
   [SourceComposable, Composable<Resolver>]
 > extends Composable[]
-  ? Awaited<ReturnType<Resolver>> extends null
-    ? SourceComposable
-    : CanComposeInSequence<
-        [SourceComposable, Awaited<ReturnType<Resolver>>]
-      > extends [Composable, ...any]
-    ? Composable<
-        (
-          ...args: Parameters<
-            CanComposeInSequence<
-              [SourceComposable, Awaited<ReturnType<Resolver>>]
-            >[0]
-          >
-        ) => null extends Awaited<ReturnType<Resolver>>
-          ?
-              | UnpackData<SourceComposable>
-              | UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
-          : UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
-      >
-    : CanComposeInSequence<[SourceComposable, Awaited<ReturnType<Resolver>>]>
+  ? Awaited<ReturnType<Resolver>> extends null ? SourceComposable
+  : CanComposeInSequence<
+    [SourceComposable, Awaited<ReturnType<Resolver>>]
+  > extends [Composable, ...any] ? Composable<
+      (
+        ...args: Parameters<
+          CanComposeInSequence<
+            [SourceComposable, Awaited<ReturnType<Resolver>>]
+          >[0]
+        >
+      ) => null extends Awaited<ReturnType<Resolver>> ?
+          | UnpackData<SourceComposable>
+          | UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
+        : UnpackData<Extract<Awaited<ReturnType<Resolver>>, Composable>>
+    >
+  : CanComposeInSequence<[SourceComposable, Awaited<ReturnType<Resolver>>]>
   : CanComposeInSequence<[SourceComposable, Composable<Resolver>]>
 
 export type {
@@ -222,7 +215,7 @@ export type {
   Result,
   SequenceReturn,
   SerializableError,
-  SerializedResult,
+  SerializableResult,
   Success,
   UnpackAll,
   UnpackData,


### PR DESCRIPTION
The idea is that if we export functions such as `isInputError` we can use them across the network after deserializing.

- [x] Create deserializers
- [x] Add tests
- [x] Decide on naming