### PR TITLE
Edit example to use more `composable` then `withSchema`

### DIFF
--- a/examples/remix/app/business/colors.ts
+++ b/examples/remix/app/business/colors.ts
@@ -1,5 +1,5 @@
 import * as z from 'zod'
-import { withSchema } from 'composable-functions'
+import { composable, withSchema } from 'composable-functions'
 import { makeService } from 'make-service'
 
 const reqRes = makeService('https://reqres.in/api')
@@ -12,14 +12,12 @@ const colorSchema = z.object({
   pantone_value: z.string(),
 })
 
-const listColors = withSchema(z.object({ page: z.string().optional() }))(
-  async ({ page = '1' }) => {
-    const response = await reqRes.get('/colors', { query: { page } })
-    return response.json(z.object({ data: z.array(colorSchema) }))
-  },
-)
+const listColors = composable(async ({ page = '1' }: { page?: string }) => {
+  const response = await reqRes.get('/colors', { query: { page } })
+  return response.json(z.object({ data: z.array(colorSchema) }))
+})
 
-const getColor = withSchema(z.object({ id: z.string() }))(async ({ id }) => {
+const getColor = composable(async ({ id }: { id: string }) => {
   const response = await reqRes.get('/colors/:id', { params: { id } })
   return response.json(z.object({ data: colorSchema }))
 })

--- a/examples/remix/app/business/users.ts
+++ b/examples/remix/app/business/users.ts
@@ -1,5 +1,5 @@
 import * as z from 'zod'
-import { composable, withSchema } from 'composable-functions'
+import { composable } from 'composable-functions'
 import { makeService } from 'make-service'
 
 const jsonPlaceholder = makeService('https://jsonplaceholder.typicode.com')
@@ -15,12 +15,12 @@ const userSchema = z.object({
   website: z.string(),
 })
 
-const listUsers = withSchema()(async () => {
+const listUsers = composable(async () => {
   const response = await jsonPlaceholder.get('/users')
   return response.json(z.array(userSchema))
 })
 
-const getUser = withSchema(z.object({ id: z.string() }))(async ({ id }) => {
+const getUser = composable(async ({ id }: { id: string }) => {
   const response = await jsonPlaceholder.get('/users/:id', { params: { id } })
   return response.json(userSchema)
 })

--- a/examples/remix/app/routes/color.$id.tsx
+++ b/examples/remix/app/routes/color.$id.tsx
@@ -1,12 +1,16 @@
 import { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { Form, Link, useActionData, useLoaderData } from '@remix-run/react'
-import { inputFromForm } from 'composable-functions'
+import { applySchema, inputFromForm } from 'composable-functions'
 import tinycolor from 'tinycolor2'
 import { getColor, mutateColor } from '~/business/colors'
 import { actionResponse, loaderResponseOrThrow } from '~/lib'
+import { z } from 'zod'
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
-  const result = await getColor(params)
+  const result = await applySchema(
+    getColor,
+    z.object({ id: z.string() }),
+  )(params)
   return loaderResponseOrThrow(result)
 }
 

--- a/examples/remix/app/routes/user.$id.tsx
+++ b/examples/remix/app/routes/user.$id.tsx
@@ -9,6 +9,7 @@ import { z } from 'zod'
 // We could also be using `map` instead of `pipe` here
 const getData = applySchema(
   pipe(getUser, formatUser),
+  // We are adding runtime validation because the Remix's `Params` object is not strongly typed
   z.object({ id: z.string() }),
 )
 

--- a/examples/remix/app/routes/user.$id.tsx
+++ b/examples/remix/app/routes/user.$id.tsx
@@ -1,12 +1,16 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { Link, useLoaderData } from '@remix-run/react'
-import { pipe } from 'composable-functions'
+import { applySchema, pipe } from 'composable-functions'
 import { formatUser, getUser } from '~/business/users'
 import { loaderResponseOrThrow } from '~/lib'
+import { z } from 'zod'
 
 // The output of getUser will be the input of formatUser
 // We could also be using `map` instead of `pipe` here
-const getData = pipe(getUser, formatUser)
+const getData = applySchema(
+  pipe(getUser, formatUser),
+  z.object({ id: z.string() }),
+)
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const result = await getData(params)


### PR DESCRIPTION
We may want to add a note on our Docs about avoiding too much zod processing.

At least in the migration docs this can be written as a benefit.