### PR TITLE
Export additional types for extensibility sake

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,11 +34,16 @@ export {
   isInputError,
 } from './errors.ts'
 export type {
+  BranchReturn,
+  CanComposeInParallel,
+  CanComposeInSequence,
   Composable,
   Failure,
   MergeObjects,
   ParserSchema,
+  PipeReturn,
   Result,
+  SequenceReturn,
   SerializableError,
   SerializableResult,
   Success,


### PR DESCRIPTION
Having these types makes it easier for a library user to build custom combinators.

This would help prototyping new combinators, I already see a use case for us to develop the new `tap` function.