### PR TITLE
Make applySchema API similar to withSchema

### DIFF
--- a/API.md
+++ b/API.md
@@ -61,12 +61,11 @@ const fn = composable((
 }))
 
 const safeFunction = applySchema(
-  fn,
   z.object({ greeting: z.string() }),
   z.object({
     user: z.object({ name: z.string() })
   }),
-)
+)(fn)
 
 type Test = typeof safeFunction
 //   ^? Composable<(input?: unknown, env?: unknown) => { message: string }>

--- a/examples/remix/app/routes/_index.tsx
+++ b/examples/remix/app/routes/_index.tsx
@@ -7,6 +7,10 @@ import { loaderResponseOrThrow } from '~/lib'
 import { z } from 'zod'
 
 const getData = applySchema(
+  // We are applying a schema for runtime safety
+  // By not defining schemas for every composable we avoid unnecessary processing
+  z.object({ page: z.string().optional() }),
+)(
   // We'll run these 2 composables in parallel with Promise.all
   collect({
     // The second argument will transform the successful result of listColors,
@@ -14,9 +18,6 @@ const getData = applySchema(
     colors: map(listColors, ({ data }) => data),
     users: listUsers,
   }),
-  // We are applying a schema for runtime safety
-  // By not defining schemas for every composable we avoid unnecessary processing
-  z.object({ page: z.string().optional() }),
 )
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   // inputFromUrl gets the queryString out of the request and turns it into an object

--- a/examples/remix/app/routes/color.$id.tsx
+++ b/examples/remix/app/routes/color.$id.tsx
@@ -7,10 +7,9 @@ import { actionResponse, loaderResponseOrThrow } from '~/lib'
 import { z } from 'zod'
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
-  const result = await applySchema(
-    getColor,
-    z.object({ id: z.string() }),
-  )(params)
+  const result = await applySchema(z.object({ id: z.string() }))(getColor)(
+    params,
+  )
   return loaderResponseOrThrow(result)
 }
 

--- a/examples/remix/app/routes/user.$id.tsx
+++ b/examples/remix/app/routes/user.$id.tsx
@@ -5,12 +5,13 @@ import { formatUser, getUser } from '~/business/users'
 import { loaderResponseOrThrow } from '~/lib'
 import { z } from 'zod'
 
-// The output of getUser will be the input of formatUser
-// We could also be using `map` instead of `pipe` here
 const getData = applySchema(
-  pipe(getUser, formatUser),
   // We are adding runtime validation because the Remix's `Params` object is not strongly typed
   z.object({ id: z.string() }),
+)(
+  // The output of getUser will be the input of formatUser
+  // We could also be using `map` instead of `pipe` here
+  pipe(getUser, formatUser),
 )
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {

--- a/migrating-df.md
+++ b/migrating-df.md
@@ -243,7 +243,7 @@ expect(result.errors).containSubset([{ name: 'InputError', path: ['name'] }])
 | Domain Functions | Composable Functions |
 |---|---|
 | `makeDomainFunction(z.string(), z.number())((input, env) => {})` | `withSchema(z.string, z.number())((input, env) => {})` |
-| -- | `applySchema(composable((input, env) => {}), z.string(), z.number())` |
+| -- | `applySchema(z.string(), z.number())(composable((input, env) => {}))` |
 | `makeSuccessResult(1)` | `success(1)` |
 | `makeErrorResult({ errors: [{ message: 'Something went wrong' }] })` | `failure([new Error('Something went wrong')])` |
 | `new InputError('required', 'user.name')` | `new InputError('required', ['user', 'name'])` |

--- a/src/tests/constructors.test.ts
+++ b/src/tests/constructors.test.ts
@@ -439,12 +439,13 @@ describe('applySchema', () => {
     const envSchema = z.object({ uid: z.preprocess(Number, z.number()) })
 
     const handler = applySchema(
+      inputSchema,
+      envSchema,
+    )(
       composable(
         ({ id }: { id: number }, { uid }: { uid: number }) =>
           [id, uid] as const,
       ),
-      inputSchema,
-      envSchema,
     )
     type _R = Expect<
       Equal<

--- a/with-schema.md
+++ b/with-schema.md
@@ -10,7 +10,7 @@ To ensure type safety at runtime, use the `applySchema` or `withSchema` function
 
 ### applySchema
 
-The `applySchema` function takes a composable and schemas for the input and environment, applying these schemas to ensure data integrity.
+The `applySchema` function takes a schemas for the input and environment, and a composable, applying these schemas to ensure data integrity.
 
 ```typescript
 import { composable, applySchema } from 'composable-functions'
@@ -21,12 +21,12 @@ const fn = composable(({ greeting }: { greeting: string }, { user }: { user: { n
 }))
 
 const safeFunction = applySchema(
-  fn,
   z.object({ greeting: z.string() }),
   z.object({ user: z.object({ name: z.string() }) })
 )
+const fnWithSchema = safeFunction(fn)
 
-type Test = typeof safeFunction
+type Test = typeof fnWithSchema
 //   ^? Composable<(input?: unknown, env?: unknown) => { message: string }>
 ```
 


### PR DESCRIPTION
This proposal aims to unify the API of `applySchema` and `withSchema` similar to what we have currently with `pipe` and `map` which are almost equivalent but one receives a handler and the other receives a composable.

The gain is consistency. I've had a feedback that keeping the schemas at the end of `applySchema` would feel like they would validate the output instead of the input of the composable.

The change seems straightforward and it is a good timing - before v1 - to act quickly ;)